### PR TITLE
Quantum mode flag

### DIFF
--- a/MKCpu.cpp
+++ b/MKCpu.cpp
@@ -150,7 +150,7 @@ void MKCpu::InitCpu()
 		{OPCODE_ILL_0C,		{OPCODE_ILL_0C,		ADDRMODE_IMP,		2,		"NOP",	&MKCpu::OpCodeDud		/*0c*/	}},
 		{OPCODE_ORA_ABS,	{OPCODE_ORA_ABS,	ADDRMODE_ABS,		4,		"ORA",	&MKCpu::OpCodeOraAbs 		/*0d*/	}},
 		{OPCODE_ASL_ABS,	{OPCODE_ASL_ABS,	ADDRMODE_ABS,		6,		"ASL",	&MKCpu::OpCodeAslAbs 		/*0e*/	}},
-		{OPCODE_ILL_0F,		{OPCODE_ILL_0F,		ADDRMODE_ABS,		6,		"SLO",	&MKCpu::OpCodeDud 		/*0f*/	}},
+		{OPCODE_SEN,		{OPCODE_SEN,		ADDRMODE_IMP,		6,		"SEN",	&MKCpu::OpCodeSen 		/*0f*/	}},
 		{OPCODE_BPL_REL,	{OPCODE_BPL_REL,	ADDRMODE_REL,		2,		"BPL",	&MKCpu::OpCodeBplRel 		/*10*/	}},
 		{OPCODE_ORA_IZY,	{OPCODE_ORA_IZY,	ADDRMODE_IZY,		5,		"ORA",	&MKCpu::OpCodeOraIzy 		/*11*/	}},
 		{OPCODE_PAX_A,		{OPCODE_PAX_A,		ADDRMODE_IMP,		3,		"PXA",	&MKCpu::OpCodeXA 		/*12*/	}},
@@ -174,15 +174,15 @@ void MKCpu::InitCpu()
 		{OPCODE_BIT_ZP,		{OPCODE_BIT_ZP,		ADDRMODE_ZP,		3,		"BIT",	&MKCpu::OpCodeBitZp 		/*24*/	}},
 		{OPCODE_AND_ZP,		{OPCODE_AND_ZP,		ADDRMODE_ZP,		3,		"AND",	&MKCpu::OpCodeAndZp 		/*25*/	}},
 		{OPCODE_ROL_ZP,		{OPCODE_ROL_ZP,		ADDRMODE_ZP,		5,		"ROL",	&MKCpu::OpCodeRolZp 		/*26*/	}},
-		{OPCODE_ILL_27,		{OPCODE_ILL_27,		ADDRMODE_ZP,		5,		"RLA",	&MKCpu::OpCodeDud 		/*27*/	}},
+		{OPCODE_SEV,		{OPCODE_SEV,		ADDRMODE_IMP,		2,		"SEV",	&MKCpu::OpCodeSev 		/*27*/	}},
 		{OPCODE_PLP,		{OPCODE_PLP,		ADDRMODE_IMP,		4,		"PLP",	&MKCpu::OpCodePlp		/*28*/	}},
 		{OPCODE_AND_IMM,	{OPCODE_AND_IMM,	ADDRMODE_IMM,		2,		"AND",	&MKCpu::OpCodeAndImm 		/*29*/	}},
 		{OPCODE_ROL,		{OPCODE_ROL,		ADDRMODE_ACC,		2,		"ROL",	&MKCpu::OpCodeRolAcc		/*2a*/	}},
-		{OPCODE_ILL_2B,		{OPCODE_ILL_2B,		ADDRMODE_IMM,		2,		"ANC",	&MKCpu::OpCodeDud 		/*2b*/	}},
+		{OPCODE_SEZ,		{OPCODE_SEZ,		ADDRMODE_IMP,		2,		"SEZ",	&MKCpu::OpCodeSez 		/*2b*/	}},
 		{OPCODE_BIT_ABS,	{OPCODE_BIT_ABS,	ADDRMODE_ABS,		4,		"BIT",	&MKCpu::OpCodeBitAbs 		/*2c*/	}},
 		{OPCODE_AND_ABS,	{OPCODE_AND_ABS,	ADDRMODE_ABS,		4,		"AND",	&MKCpu::OpCodeAndAbs 		/*2d*/	}},
 		{OPCODE_ROL_ABS,	{OPCODE_ROL_ABS,	ADDRMODE_ABS,		6,		"ROL",	&MKCpu::OpCodeRolAbs 		/*2e*/	}},
-		{OPCODE_ILL_2F,		{OPCODE_ILL_2F,		ADDRMODE_ABS,		6,		"RLA",	&MKCpu::OpCodeDud 		/*2f*/	}},
+		{OPCODE_CLN,		{OPCODE_CLN,		ADDRMODE_IMP,		2,		"CLN",	&MKCpu::OpCodeCln 		/*2f*/	}},
 		{OPCODE_BMI_REL,	{OPCODE_BMI_REL,	ADDRMODE_REL,		2,		"BMI",	&MKCpu::OpCodeBmiRel 		/*30*/	}},
 		{OPCODE_AND_IZY,	{OPCODE_AND_IZY,	ADDRMODE_IZY,		5,		"AND",	&MKCpu::OpCodeAndIzy 		/*31*/	}},
 		{OPCODE_PAZ_A,		{OPCODE_PAZ_A,		ADDRMODE_IMP,		3,		"PZA",	&MKCpu::OpCodeZA 		/*32*/	}},
@@ -190,7 +190,7 @@ void MKCpu::InitCpu()
 		{OPCODE_ILL_34,		{OPCODE_ILL_34,		ADDRMODE_IMP,		3,		"PZY",	&MKCpu::OpCodeDud 		/*34*/	}},
 		{OPCODE_AND_ZPX,	{OPCODE_AND_ZPX,	ADDRMODE_ZPX,		4,		"AND",	&MKCpu::OpCodeAndZpx 		/*35*/	}},
 		{OPCODE_ROL_ZPX,	{OPCODE_ROL_ZPX,	ADDRMODE_ZPX,		6,		"ROL",	&MKCpu::OpCodeRolZpx 		/*36*/	}},
-		{OPCODE_ILL_37,		{OPCODE_ILL_37,		ADDRMODE_ZPX,		6,		"RLA",	&MKCpu::OpCodeDud 		/*37*/	}},
+		{OPCODE_ILL_37,		{OPCODE_ILL_37,		ADDRMODE_ZPX,		2,		"RLA",	&MKCpu::OpCodeDud  		/*37*/	}},
 		{OPCODE_SEC,		{OPCODE_SEC,		ADDRMODE_IMP,		2,		"SEC",	&MKCpu::OpCodeSec		/*38*/	}},
 		{OPCODE_AND_ABY,	{OPCODE_AND_ABY,	ADDRMODE_ABY,		4,		"AND",	&MKCpu::OpCodeAndAby 		/*39*/	}},
 		{OPCODE_ROT_A,		{OPCODE_ROT_A,		ADDRMODE_IMP,		2,		"R1A",	&MKCpu::OpCodeR1A 		/*3a*/	}},
@@ -206,7 +206,7 @@ void MKCpu::InitCpu()
 		{OPCODE_ILL_44,		{OPCODE_ILL_44,		ADDRMODE_IMP,		3,		"RXY",	&MKCpu::OpCodeDud 		/*44*/	}},
 		{OPCODE_EOR_ZP,		{OPCODE_EOR_ZP,		ADDRMODE_ZP,		3,		"EOR",	&MKCpu::OpCodeEorZp 		/*45*/	}},
 		{OPCODE_LSR_ZP,		{OPCODE_LSR_ZP,		ADDRMODE_ZP,		5,		"LSR",	&MKCpu::OpCodeLsrZp 		/*46*/	}},
-		{OPCODE_ILL_47,		{OPCODE_ILL_47,		ADDRMODE_ZP,		5,		"SRE",	&MKCpu::OpCodeDud 		/*47*/	}},
+		{OPCODE_CLZ,		{OPCODE_CLZ,		ADDRMODE_IMP,		2,		"CLZ",	&MKCpu::OpCodeClz 		/*47*/	}},
 		{OPCODE_PHA,		{OPCODE_PHA,		ADDRMODE_IMP,		3,		"PHA",	&MKCpu::OpCodePha 		/*48*/	}},
 		{OPCODE_EOR_IMM,	{OPCODE_EOR_IMM,	ADDRMODE_IMM,		2,		"EOR",	&MKCpu::OpCodeEorImm 		/*49*/	}},
 		{OPCODE_LSR,		{OPCODE_LSR,		ADDRMODE_ACC,		2,		"LSR",	&MKCpu::OpCodeLsrAcc		/*4a*/	}},
@@ -382,12 +382,12 @@ void MKCpu::InitCpu()
 		{OPCODE_ILL_F4,		{OPCODE_ILL_F4,		ADDRMODE_ZPX,		4,		"NOP",	&MKCpu::OpCodeDud 		/*f4*/	}},
 		{OPCODE_SBC_ZPX,	{OPCODE_SBC_ZPX,	ADDRMODE_ZPX,		4,		"SBC",	&MKCpu::OpCodeSbcZpx 		/*f5*/	}},
 		{OPCODE_INC_ZPX,	{OPCODE_INC_ZPX,	ADDRMODE_ZPX,		6,		"INC",	&MKCpu::OpCodeIncZpx 		/*f6*/	}},
-		{OPCODE_QXN_Z,		{OPCODE_QXN_Z,		ADDRMODE_IMP,		6,		"QXZ",	&MKCpu::OpCodeQxZero 		/*f7*/	}},
+		{OPCODE_QZN_Z,		{OPCODE_QZN_Z,		ADDRMODE_IMP,		6,		"QZZ",	&MKCpu::OpCodeQzZero 		/*f7*/	}},
 		{OPCODE_SED,		{OPCODE_SED,		ADDRMODE_IMP,		2,		"SED",	&MKCpu::OpCodeSed 		/*f8*/	}},
 		{OPCODE_SBC_ABY,	{OPCODE_SBC_ABY,	ADDRMODE_ABY,		4,		"SBC",	&MKCpu::OpCodeSbcAby 		/*f9*/	}},
-		{OPCODE_QXN_S,		{OPCODE_QXN_S,		ADDRMODE_IMP,		2,		"QXS",	&MKCpu::OpCodeQxSign 		/*fa*/	}},
-		{OPCODE_QXN_C,		{OPCODE_QXN_C,		ADDRMODE_IMP,		2,		"QXC",	&MKCpu::OpCodeQxCarry 		/*fb*/	}},
-		{OPCODE_ILL_FC,		{OPCODE_ILL_FC,		ADDRMODE_IMP,		2,		"QXO",	&MKCpu::OpCodeQxOver 		/*fc*/	}},
+		{OPCODE_QZN_S,		{OPCODE_QZN_S,		ADDRMODE_IMP,		2,		"QZS",	&MKCpu::OpCodeQzSign 		/*fa*/	}},
+		{OPCODE_QZN_C,		{OPCODE_QZN_C,		ADDRMODE_IMP,		2,		"QZC",	&MKCpu::OpCodeQzCarry 		/*fb*/	}},
+		{OPCODE_ILL_FC,		{OPCODE_ILL_FC,		ADDRMODE_IMP,		2,		"QZO",	&MKCpu::OpCodeQzOver 		/*fc*/	}},
 		{OPCODE_SBC_ABX,	{OPCODE_SBC_ABX,	ADDRMODE_ABX,		4,		"SBC",	&MKCpu::OpCodeSbcAbx 		/*fd*/	}},
 		{OPCODE_INC_ABX,	{OPCODE_INC_ABX,	ADDRMODE_ABX,		7,		"INC",	&MKCpu::OpCodeIncAbx 		/*fe*/	}},
 		{OPCODE_ILL_FF,		{OPCODE_ILL_FF,		ADDRMODE_ABX,		7,		"ISC",	&MKCpu::OpCodeDud 		/*ff*/	}}
@@ -462,11 +462,7 @@ unsigned char MKCpu::RotateClassical(unsigned char reg) {
  */
 void MKCpu::SetFlags(unsigned char reg)
 {
-	if (mReg.Flags & FLAGS_QUANTUM) {
-		SetFlag((0 == reg) != (mReg.Flags & FLAGS_ZERO), FLAGS_ZERO);
-		SetFlag(((reg & FLAGS_SIGN) == FLAGS_SIGN) != (mReg.Flags & FLAGS_SIGN), FLAGS_SIGN);
-	}
-	else {
+	if (!(mReg.Flags & FLAGS_QUANTUM)) {
 		SetFlag((0 == reg), FLAGS_ZERO);
 		SetFlag(((reg & FLAGS_SIGN) == FLAGS_SIGN), FLAGS_SIGN);
 	}
@@ -703,8 +699,9 @@ void MKCpu::LogicOpAcc(unsigned short addr, int logop)
 void MKCpu::CompareOpAcc(unsigned char val)
 {
 	if (mReg.Flags & FLAGS_QUANTUM) {
-		qReg->DECC(val, REGS_ACC_Q, REG_LEN, FLAGS_CARRY_Q);
-		qReg->X(FLAGS_CARRY_Q);
+		//qReg->DECC(val, REGS_ACC_Q, REG_LEN, FLAGS_CARRY_Q);
+		//qReg->X(FLAGS_CARRY_Q);
+		qReg->DEC(val, REGS_ACC_Q, REG_LEN);
 		qReg->SetZeroFlag(REGS_ACC_Q, REG_LEN, FLAGS_ZERO_Q);
 		qReg->SetSignFlag(REGS_ACC_Q + REG_LEN - 1, FLAGS_SIGN_Q);
 		qReg->INC(val, REGS_ACC_Q, REG_LEN);
@@ -3269,66 +3266,62 @@ void MKCpu::OpCodeHaz()
 
 /*
  *--------------------------------------------------------------------
- * Method:		OpCodeQxZero()
- * Purpose:		X operator on zero flag qubit, IMPlied addressing mode.
+ * Method:		OpCodeQzZero()
+ * Purpose:		Z operator on zero flag qubit, IMPlied addressing mode.
  * Arguments:	n/a
  * Returns:		n/a
  *--------------------------------------------------------------------
  */
-void MKCpu::OpCodeQxZero()
+void MKCpu::OpCodeQzZero()
 {
 	// Hadamard overflow, Implied ($18 : CLC)
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qReg->X(FLAGS_ZERO_Q);
-	if (mReg.Flags & FLAGS_QUANTUM) mReg.Flags ^= FLAGS_ZERO;
+	qReg->Z(FLAGS_ZERO_Q);
 }
 
 /*
  *--------------------------------------------------------------------
- * Method:		OpCodeQxSign()
- * Purpose:		X operator on sign flag qubit, IMPlied addressing mode.
+ * Method:		OpCodeQzSign()
+ * Purpose:		Z operator on sign flag qubit, IMPlied addressing mode.
  * Arguments:	n/a
  * Returns:		n/a
  *--------------------------------------------------------------------
  */
-void MKCpu::OpCodeQxSign()
+void MKCpu::OpCodeQzSign()
 {
 	// Hadamard overflow, Implied ($18 : CLC)
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qReg->X(FLAGS_SIGN_Q);
-	if (mReg.Flags & FLAGS_QUANTUM) mReg.Flags ^= FLAGS_SIGN;
+	qReg->Z(FLAGS_SIGN_Q);
 }
 
 /*
  *--------------------------------------------------------------------
- * Method:		OpCodeQxCarry()
- * Purpose:		X operator on carry flag qubit, IMPlied addressing mode.
+ * Method:		OpCodeQzCarry()
+ * Purpose:		Z operator on carry flag qubit, IMPlied addressing mode.
  * Arguments:	n/a
  * Returns:		n/a
  *--------------------------------------------------------------------
  */
-void MKCpu::OpCodeQxCarry()
+void MKCpu::OpCodeQzCarry()
 {
 	// Hadamard overflow, Implied ($18 : CLC)
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qReg->X(FLAGS_CARRY_Q);
-	if (mReg.Flags & FLAGS_QUANTUM) mReg.Flags ^= FLAGS_CARRY;
+	qReg->Z(FLAGS_CARRY_Q);
 }
 
 /*
  *--------------------------------------------------------------------
- * Method:		OpCodeQxOver()
- * Purpose:		X operator on overflow flag qubit, IMPlied addressing mode.
+ * Method:		OpCodeQzOver()
+ * Purpose:		Z operator on overflow flag qubit, IMPlied addressing mode.
  * Arguments:	n/a
  * Returns:		n/a
  *--------------------------------------------------------------------
  */
-void MKCpu::OpCodeQxOver()
+void MKCpu::OpCodeQzOver()
 {
 	// Hadamard overflow, Implied ($18 : CLC)
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qReg->X(FLAGS_OVERFLOW_Q);
-	if (mReg.Flags & FLAGS_QUANTUM) mReg.Flags ^= FLAGS_OVERFLOW;
+	qReg->Z(FLAGS_OVERFLOW_Q);
 }
 
 /*
@@ -4780,6 +4773,76 @@ void MKCpu::OpCodeFTX()
 	qReg->QFT(REGS_INDX_Q, REG_LEN);
 	SetFlagsRegQ(REGS_INDX_Q);
 	//TODO: Implement classical Fourier transform, here.
+}
+
+/*
+ *--------------------------------------------------------------------
+ * Method:		OpCodeSen()
+ * Purpose:		SEt Negative flag, for quantum mode
+ * Arguments:		n/a
+ * Returns:		n/a
+ *--------------------------------------------------------------------
+ */
+void MKCpu::OpCodeSen()
+{
+	mReg.Flags |= FLAGS_SIGN;
+	qReg->SetBit(FLAGS_SIGN_Q, true);
+}
+
+/*
+ *--------------------------------------------------------------------
+ * Method:		OpCodeCln()
+ * Purpose:		CLear Negative flag, for quantum mode
+ * Arguments:		n/a
+ * Returns:		n/a
+ *--------------------------------------------------------------------
+ */
+void MKCpu::OpCodeCln()
+{
+	mReg.Flags &= (~FLAGS_SIGN);
+	qReg->SetBit(FLAGS_SIGN_Q, false);
+}
+
+/*
+ *--------------------------------------------------------------------
+ * Method:		OpCodeSev()
+ * Purpose:		SEt oVerflow flag, for quantum mode
+ * Arguments:		n/a
+ * Returns:		n/a
+ *--------------------------------------------------------------------
+ */
+void MKCpu::OpCodeSev()
+{
+	mReg.Flags |= FLAGS_OVERFLOW;
+	qReg->SetBit(FLAGS_OVERFLOW_Q, true);
+}
+
+/*
+ *--------------------------------------------------------------------
+ * Method:		OpCodeSez()
+ * Purpose:		SEt Zero flag, for quantum mode
+ * Arguments:		n/a
+ * Returns:		n/a
+ *--------------------------------------------------------------------
+ */
+void MKCpu::OpCodeSez()
+{
+	mReg.Flags |= FLAGS_ZERO;
+	qReg->SetBit(FLAGS_ZERO_Q, true);
+}
+
+/*
+ *--------------------------------------------------------------------
+ * Method:		OpCodeClz()
+ * Purpose:		CLear Zero flag, for quantum mode
+ * Arguments:		n/a
+ * Returns:		n/a
+ *--------------------------------------------------------------------
+ */
+void MKCpu::OpCodeClz()
+{
+	mReg.Flags &= (~FLAGS_ZERO);
+	qReg->SetBit(FLAGS_ZERO_Q, false);
 }
 
 /*

--- a/MKCpu.cpp
+++ b/MKCpu.cpp
@@ -43,7 +43,7 @@ Qrack::CoherentUnitEngine coherentUnitEngine = Qrack::COHERENT_UNIT_ENGINE_OPENC
 Qrack::CoherentUnitEngine coherentUnitEngine = Qrack::COHERENT_UNIT_ENGINE_SOFTWARE;
 #endif
 
-Qrack::CoherentUnit *qRegs = NULL;
+Qrack::CoherentUnit *qReg = NULL;
 
 namespace MKBasic {
 
@@ -141,7 +141,7 @@ void MKCpu::InitCpu()
 		{OPCODE_HAD_Y,		{OPCODE_HAD_Y,		ADDRMODE_IMP,		3,		"HAY",	&MKCpu::OpCodeDud		/*04*/	}},
 		{OPCODE_ORA_ZP,		{OPCODE_ORA_ZP,		ADDRMODE_ZP,		3,		"ORA", 	&MKCpu::OpCodeOraZp		/*05*/	}},
 		{OPCODE_ASL_ZP,		{OPCODE_ASL_ZP,		ADDRMODE_ZP,		5,		"ASL",	&MKCpu::OpCodeAslZp		/*06*/	}},
-		{OPCODE_HAD_O,		{OPCODE_HAD_O,		ADDRMODE_IMP,		2,		"HAO",	&MKCpu::OpCodeHao		/*07*/	}},
+		{OPCODE_HAD_O,		{OPCODE_HAD_O,		ADDRMODE_IMP,		2,		"HAS",	&MKCpu::OpCodeHas		/*07*/	}},
 		{OPCODE_PHP,		{OPCODE_PHP,		ADDRMODE_IMP,		3,		"PHP",	&MKCpu::OpCodePhp		/*08*/	}},
 		{OPCODE_ORA_IMM,	{OPCODE_ORA_IMM,	ADDRMODE_IMM,		2,		"ORA",	&MKCpu::OpCodeOraImm 		/*09*/	}},
 		{OPCODE_ASL,		{OPCODE_ASL,		ADDRMODE_ACC,		2,		"ASL",	&MKCpu::OpCodeAslAcc		/*0a*/	}},
@@ -154,7 +154,7 @@ void MKCpu::InitCpu()
 		{OPCODE_ORA_IZY,	{OPCODE_ORA_IZY,	ADDRMODE_IZY,		5,		"ORA",	&MKCpu::OpCodeOraIzy 		/*11*/	}},
 		{OPCODE_PAX_A,		{OPCODE_PAX_A,		ADDRMODE_IMP,		3,		"PXA",	&MKCpu::OpCodeXA 		/*12*/	}},
 		{OPCODE_PAX_X,		{OPCODE_PAX_X,		ADDRMODE_IMP,		3,		"PXX",	&MKCpu::OpCodeXX 		/*13*/	}},
-		{OPCODE_PAX_O,		{OPCODE_PAX_O,		ADDRMODE_IMP,		3,		"PXO",	&MKCpu::OpCodeXO 		/*14*/	}},
+		{OPCODE_PAX_O,		{OPCODE_PAX_O,		ADDRMODE_IMP,		3,		"PXO",	&MKCpu::OpCodeDud 		/*14*/	}},
 		{OPCODE_ORA_ZPX,	{OPCODE_ORA_ZPX,	ADDRMODE_ZPX,		4,		"ORA",	&MKCpu::OpCodeOraZpx 		/*15*/	}},
 		{OPCODE_ASL_ZPX,	{OPCODE_ASL_ZPX,	ADDRMODE_ZPX,		6,		"ASL",	&MKCpu::OpCodeAslZpx 		/*16*/	}},
 		{OPCODE_HAD_C,		{OPCODE_HAD_C,		ADDRMODE_IMP,		4,		"HAC",	&MKCpu::OpCodeHac 		/*17*/	}},
@@ -165,7 +165,7 @@ void MKCpu::InitCpu()
 		{OPCODE_ILL_1C,		{OPCODE_ILL_1C,		ADDRMODE_IMP,		4,		"PYY",	&MKCpu::OpCodeDud 		/*1c*/	}},
 		{OPCODE_ORA_ABX,	{OPCODE_ORA_ABX,	ADDRMODE_ABX,		4,		"ORA",	&MKCpu::OpCodeOraAbx 		/*1d*/	}},
 		{OPCODE_ASL_ABX,	{OPCODE_ASL_ABX,	ADDRMODE_ABX,		7,		"ASL",	&MKCpu::OpCodeAslAbx 		/*1e*/	}},
-		{OPCODE_CLO,		{OPCODE_CLO,		ADDRMODE_IMP,		2,		"NOP",	&MKCpu::OpCodeClo 		/*1f*/	}},
+		{OPCODE_CLQ,		{OPCODE_CLQ,		ADDRMODE_IMP,		2,		"CLQ",	&MKCpu::OpCodeClq 		/*1f*/	}},
 		{OPCODE_JSR_ABS,	{OPCODE_JSR_ABS,	ADDRMODE_ABS,		6,		"JSR",	&MKCpu::OpCodeJsrAbs 		/*20*/	}},
 		{OPCODE_AND_IZX,	{OPCODE_AND_IZX,	ADDRMODE_IZX,		6,		"AND",	&MKCpu::OpCodeAndIzx 		/*21*/	}},
 		{OPCODE_ILL_22,		{OPCODE_ILL_22,		ADDRMODE_UND,		0,		"ILL",	&MKCpu::OpCodeDud 		/*22*/	}},
@@ -197,7 +197,7 @@ void MKCpu::InitCpu()
 		{OPCODE_ILL_3C,		{OPCODE_ILL_3C,		ADDRMODE_IMP,		4,		"R1Y",	&MKCpu::OpCodeDud 		/*3c*/	}},
 		{OPCODE_AND_ABX,	{OPCODE_AND_ABX,	ADDRMODE_ABX,		4,		"AND",	&MKCpu::OpCodeAndAbx 		/*3d*/	}},
 		{OPCODE_ROL_ABX,	{OPCODE_ROL_ABX,	ADDRMODE_ABX,		7,		"ROL",	&MKCpu::OpCodeRolAbx 		/*3e*/	}},
-		{OPCODE_SEO,		{OPCODE_SEO,		ADDRMODE_IMP,		2,		"SEO",	&MKCpu::OpCodeSeo		/*3f*/	}},
+		{OPCODE_SEQ,		{OPCODE_SEQ,		ADDRMODE_IMP,		2,		"SEQ",	&MKCpu::OpCodeSeq		/*3f*/	}},
 		{OPCODE_RTI,		{OPCODE_RTI,		ADDRMODE_IMP,		6,		"RTI",	&MKCpu::OpCodeRti		/*40*/	}},
 		{OPCODE_EOR_IZX,	{OPCODE_EOR_IZX,	ADDRMODE_IZX,		6,		"EOR",	&MKCpu::OpCodeEorIzx 		/*41*/	}},
 		{OPCODE_ROTX_A,		{OPCODE_ROTX_A,		ADDRMODE_IMP,		3,		"RXA",	&MKCpu::OpCodeRXA 		/*42*/	}},
@@ -325,7 +325,7 @@ void MKCpu::InitCpu()
 		{OPCODE_LDY_ABX,	{OPCODE_LDY_ABX,	ADDRMODE_ABX,		4,		"LDY",	&MKCpu::OpCodeLdyAbx 		/*bc*/	}},
 		{OPCODE_LDA_ABX,	{OPCODE_LDA_ABX,	ADDRMODE_ABX,		4,		"LDA",	&MKCpu::OpCodeLdaAbx 		/*bd*/	}},
 		{OPCODE_LDX_ABY,	{OPCODE_LDX_ABY,	ADDRMODE_ABY,		4,		"LDX",	&MKCpu::OpCodeLdxAby 		/*be*/	}},
-		{OPCODE_ILL_BF,		{OPCODE_ILL_BF,		ADDRMODE_ABY,		4,		"LAX",	&MKCpu::OpCodeDud 		/*bf*/	}},
+		{OPCODE_ILL_BF,		{OPCODE_ILL_BF,		ADDRMODE_ABY,		2,		"NOP",	&MKCpu::OpCodeNop 		/*bf*/	}},
 		{OPCODE_CPY_IMM,	{OPCODE_CPY_IMM,	ADDRMODE_IMM,		2,		"CPY",	&MKCpu::OpCodeCpyImm 		/*c0*/	}},
 		{OPCODE_CMP_IZX,	{OPCODE_CMP_IZX,	ADDRMODE_IZX,		6,		"CMP",	&MKCpu::OpCodeCmpIzx 		/*c1*/	}},
 		{OPCODE_ILL_C2,		{OPCODE_ILL_C2,		ADDRMODE_IMM,		2,		"NOP",	&MKCpu::OpCodeDud 		/*c2*/	}},
@@ -333,7 +333,7 @@ void MKCpu::InitCpu()
 		{OPCODE_CPY_ZP,		{OPCODE_CPY_ZP,		ADDRMODE_ZP,		3,		"CPY",	&MKCpu::OpCodeCpyZp 		/*c4*/	}},
 		{OPCODE_CMP_ZP,		{OPCODE_CMP_ZP,		ADDRMODE_ZP,		3,		"CMP",	&MKCpu::OpCodeCmpZp 		/*c5*/	}},
 		{OPCODE_DEC_ZP,		{OPCODE_DEC_ZP,		ADDRMODE_ZP,		5,		"DEC",	&MKCpu::OpCodeDecZp 		/*c6*/	}},
-		{OPCODE_ILL_C7,		{OPCODE_ILL_C7,		ADDRMODE_ZP,		5,		"DCP",	&MKCpu::OpCodeDud 		/*c7*/	}},
+		{OPCODE_ILL_C7,		{OPCODE_ILL_C7,		ADDRMODE_ZP,		2,		"HAZ",	&MKCpu::OpCodeHaz 		/*c7*/	}},
 		{OPCODE_INY,		{OPCODE_INY,		ADDRMODE_IMP,		2,		"INY",	&MKCpu::OpCodeIny 		/*c8*/	}},
 		{OPCODE_CMP_IMM,	{OPCODE_CMP_IMM,	ADDRMODE_IMM,		2,		"CMP",	&MKCpu::OpCodeCmpImm 		/*c9*/	}},
 		{OPCODE_DEX,		{OPCODE_DEX,		ADDRMODE_IMP,		2,		"DEX",	&MKCpu::OpCodeDex 		/*ca*/	}},
@@ -381,12 +381,12 @@ void MKCpu::InitCpu()
 		{OPCODE_ILL_F4,		{OPCODE_ILL_F4,		ADDRMODE_ZPX,		4,		"NOP",	&MKCpu::OpCodeDud 		/*f4*/	}},
 		{OPCODE_SBC_ZPX,	{OPCODE_SBC_ZPX,	ADDRMODE_ZPX,		4,		"SBC",	&MKCpu::OpCodeSbcZpx 		/*f5*/	}},
 		{OPCODE_INC_ZPX,	{OPCODE_INC_ZPX,	ADDRMODE_ZPX,		6,		"INC",	&MKCpu::OpCodeIncZpx 		/*f6*/	}},
-		{OPCODE_OCN_Z,		{OPCODE_OCN_Z,		ADDRMODE_IMP,		6,		"OCZ",	&MKCpu::OpCodeOcnZero 		/*f7*/	}},
+		{OPCODE_QXN_Z,		{OPCODE_QXN_Z,		ADDRMODE_IMP,		6,		"QXZ",	&MKCpu::OpCodeQxZero 		/*f7*/	}},
 		{OPCODE_SED,		{OPCODE_SED,		ADDRMODE_IMP,		2,		"SED",	&MKCpu::OpCodeSed 		/*f8*/	}},
 		{OPCODE_SBC_ABY,	{OPCODE_SBC_ABY,	ADDRMODE_ABY,		4,		"SBC",	&MKCpu::OpCodeSbcAby 		/*f9*/	}},
-		{OPCODE_OCN_S,		{OPCODE_OCN_S,		ADDRMODE_IMP,		2,		"OCS",	&MKCpu::OpCodeOcnSign 		/*fa*/	}},
-		{OPCODE_OCN_C,		{OPCODE_OCN_C,		ADDRMODE_IMP,		2,		"OCC",	&MKCpu::OpCodeOcnCarry 		/*fb*/	}},
-		{OPCODE_OCN_O,		{OPCODE_OCN_O,		ADDRMODE_IMP,		2,		"OCO",	&MKCpu::OpCodeOcnOver 		/*fc*/	}},
+		{OPCODE_QXN_S,		{OPCODE_QXN_S,		ADDRMODE_IMP,		2,		"QXS",	&MKCpu::OpCodeQxSign 		/*fa*/	}},
+		{OPCODE_QXN_C,		{OPCODE_QXN_C,		ADDRMODE_IMP,		2,		"QXC",	&MKCpu::OpCodeQxCarry 		/*fb*/	}},
+		{OPCODE_ILL_FC,		{OPCODE_ILL_FC,		ADDRMODE_IMP,		2,		"QXO",	&MKCpu::OpCodeQxOver 		/*fc*/	}},
 		{OPCODE_SBC_ABX,	{OPCODE_SBC_ABX,	ADDRMODE_ABX,		4,		"SBC",	&MKCpu::OpCodeSbcAbx 		/*fd*/	}},
 		{OPCODE_INC_ABX,	{OPCODE_INC_ABX,	ADDRMODE_ABX,		7,		"INC",	&MKCpu::OpCodeIncAbx 		/*fe*/	}},
 		{OPCODE_ILL_FF,		{OPCODE_ILL_FF,		ADDRMODE_ABX,		7,		"ISC",	&MKCpu::OpCodeDud 		/*ff*/	}}
@@ -426,8 +426,8 @@ void MKCpu::InitCpu()
 	mpMem->Poke8bitImg(0x0200,OPCODE_BRK);
 
 	// Initialize the quantum coherent register
-	qRegs = Qrack::CreateCoherentUnit(coherentUnitEngine, 21, 0);
-	if (NULL == qRegs) {
+	qReg = Qrack::CreateCoherentUnit(coherentUnitEngine, 21, 0);
+	if (NULL == qReg) {
 		throw MKGenException("Unable to acquire CoherentUnit");
 	}
 }
@@ -461,22 +461,36 @@ unsigned char MKCpu::RotateClassical(unsigned char reg) {
  */
 void MKCpu::SetFlags(unsigned char reg)
 {
-
-	SetFlag((0 == reg), FLAGS_ZERO);
-	SetFlag(((reg & FLAGS_SIGN) == FLAGS_SIGN), FLAGS_SIGN);
-	SetFlag((reg & FLAGS_ORACLE), FLAGS_ORACLE);
+	if (mReg.Flags & FLAGS_QUANTUM) {
+		SetFlag((0 == reg) != (mReg.Flags & FLAGS_ZERO), FLAGS_ZERO);
+		SetFlag(((reg & FLAGS_SIGN) == FLAGS_SIGN) != (mReg.Flags & FLAGS_SIGN), FLAGS_SIGN);
+	}
+	else {
+		SetFlag((0 == reg), FLAGS_ZERO);
+		SetFlag(((reg & FLAGS_SIGN) == FLAGS_SIGN), FLAGS_SIGN);
+	}
 }
 
 void MKCpu::SetFlagsRegQ(unsigned char start)
 {
-	qRegs->SetZeroFlag(start, REG_LEN, FLAGS_ZERO_Q);
-	qRegs->SetSignFlag(start + REG_LEN - 1, FLAGS_SIGN_Q);
+	if (!(mReg.Flags & FLAGS_QUANTUM)) {
+		qReg->SetBit(FLAGS_ZERO_Q, false);
+		qReg->SetBit(FLAGS_SIGN_Q, false);
+	}
+	qReg->SetZeroFlag(start, REG_LEN, FLAGS_ZERO_Q);
+	qReg->SetSignFlag(start + REG_LEN - 1, FLAGS_SIGN_Q);
 }
 
 void MKCpu::SetFlagsQ(unsigned char reg)
 {
-	qRegs->SetBit(FLAGS_ZERO_Q, (0 == reg));
-	qRegs->SetBit(FLAGS_SIGN_Q, ((reg & FLAGS_SIGN) == FLAGS_SIGN));
+	if (mReg.Flags & FLAGS_QUANTUM) {
+		if (0 == reg) qReg->X(FLAGS_ZERO_Q);
+		if ((reg & FLAGS_SIGN) == FLAGS_SIGN) qReg->X(FLAGS_SIGN_Q);
+	}
+	else {
+		qReg->SetBit(FLAGS_ZERO_Q, (0 == reg));
+		qReg->SetBit(FLAGS_SIGN_Q, ((reg & FLAGS_SIGN) == FLAGS_SIGN));
+	}
 }
 
 /*
@@ -490,12 +504,11 @@ void MKCpu::SetFlagsQ(unsigned char reg)
  */
 void MKCpu::MeasureFlagsQ()
 {
-	mReg.Flags &= (FLAGS_BRK | FLAGS_IRQ | FLAGS_DEC | FLAGS_ORACLE);
-	mReg.Flags |= qRegs->M(FLAGS_CARRY_Q) ? 	FLAGS_CARRY : 0;
-	mReg.Flags |= qRegs->M(FLAGS_ZERO_Q) ? 		FLAGS_ZERO : 0;
-	mReg.Flags |= qRegs->M(FLAGS_OVERFLOW_Q) ? 	FLAGS_OVERFLOW : 0;
-	mReg.Flags |= qRegs->M(FLAGS_SIGN_Q) ? 		FLAGS_SIGN : 0;
-	mReg.Flags |= qRegs->M(FLAGS_ORACLE_Q) ? 	FLAGS_ORACLE : 0;
+	mReg.Flags &= (FLAGS_BRK | FLAGS_IRQ | FLAGS_DEC | FLAGS_QUANTUM);
+	mReg.Flags |= qReg->M(FLAGS_CARRY_Q) ? 	FLAGS_CARRY : 0;
+	mReg.Flags |= qReg->M(FLAGS_ZERO_Q) ? 		FLAGS_ZERO : 0;
+	mReg.Flags |= qReg->M(FLAGS_OVERFLOW_Q) ? 	FLAGS_OVERFLOW : 0;
+	mReg.Flags |= qReg->M(FLAGS_SIGN_Q) ? 		FLAGS_SIGN : 0;
 }
 
 /*
@@ -510,10 +523,10 @@ void MKCpu::MeasureFlagsQ()
 void MKCpu::ShiftLeftQ(bitLenInt start)
 {
 	// set Carry flag based on original bit #7
-	qRegs->Swap(start + REG_LEN, FLAGS_CARRY_Q);
-	qRegs->SetBit(start + REG_LEN, 0);
-	qRegs->ROL(1, start, REG_LEN + 1);
-	qRegs->Swap(start + REG_LEN, FLAGS_CARRY_Q);
+	qReg->Swap(start + REG_LEN, FLAGS_CARRY_Q);
+	qReg->SetBit(start + REG_LEN, 0);
+	qReg->ROL(1, start, REG_LEN + 1);
+	qReg->Swap(start + REG_LEN, FLAGS_CARRY_Q);
 }
 unsigned char MKCpu::ShiftLeft(unsigned char arg8)
 {
@@ -538,10 +551,10 @@ unsigned char MKCpu::ShiftLeft(unsigned char arg8)
 void MKCpu::ShiftRightQ(bitLenInt start)
 {
 	// set Carry flag based on original bit #7
-	qRegs->Swap(start + REG_LEN, FLAGS_CARRY_Q);
-	qRegs->SetBit(start + REG_LEN, false);
-	qRegs->ROR(1, start, REG_LEN + 1);
-	qRegs->Swap(start + REG_LEN, FLAGS_CARRY_Q);
+	qReg->Swap(start + REG_LEN, FLAGS_CARRY_Q);
+	qReg->SetBit(start + REG_LEN, false);
+	qReg->ROR(1, start, REG_LEN + 1);
+	qReg->Swap(start + REG_LEN, FLAGS_CARRY_Q);
 }
 unsigned char MKCpu::ShiftRight(unsigned char arg8)
 {
@@ -565,9 +578,9 @@ unsigned char MKCpu::ShiftRight(unsigned char arg8)
 void MKCpu::RotateLeftQ(bitLenInt start)
 {
 	// set Carry flag based on original bit #7
-	qRegs->Swap(start + REG_LEN, FLAGS_CARRY_Q);
-	qRegs->ROL(1, start, REG_LEN + 1);
-	qRegs->Swap(start + REG_LEN, FLAGS_CARRY_Q);
+	qReg->Swap(start + REG_LEN, FLAGS_CARRY_Q);
+	qReg->ROL(1, start, REG_LEN + 1);
+	qReg->Swap(start + REG_LEN, FLAGS_CARRY_Q);
 } 
 unsigned char MKCpu::RotateLeft(unsigned char arg8)
 {
@@ -600,9 +613,9 @@ unsigned char MKCpu::RotateLeft(unsigned char arg8)
 void MKCpu::RotateRightQ(bitLenInt start)
 {
 	// set Carry flag based on original bit #7
-	qRegs->Swap(start + REG_LEN, FLAGS_CARRY_Q);
-	qRegs->ROR(1, start, REG_LEN + 1);
-	qRegs->Swap(start + REG_LEN, FLAGS_CARRY_Q);
+	qReg->Swap(start + REG_LEN, FLAGS_CARRY_Q);
+	qReg->ROR(1, start, REG_LEN + 1);
+	qReg->Swap(start + REG_LEN, FLAGS_CARRY_Q);
 } 
 unsigned char MKCpu::RotateRight(unsigned char arg8)
 {
@@ -663,15 +676,15 @@ void MKCpu::LogicOpAcc(unsigned short addr, int logop)
 	switch (logop) {
 		case LOGOP_OR:
 			mReg.Acc |= val;
-			qRegs->CLOR(REGS_ACC_Q, val, REGS_ACC_Q, REG_LEN);
+			qReg->CLOR(REGS_ACC_Q, val, REGS_ACC_Q, REG_LEN);
 			break;
 		case LOGOP_AND:
 			mReg.Acc &= val;
-			qRegs->CLAND(REGS_ACC_Q, val, REGS_ACC_Q, REG_LEN);
+			qReg->CLAND(REGS_ACC_Q, val, REGS_ACC_Q, REG_LEN);
 			break;
 		case LOGOP_EOR:
 			mReg.Acc ^= val;
-			qRegs->CLXOR(REGS_ACC_Q, val, REGS_ACC_Q, REG_LEN);
+			qReg->CLXOR(REGS_ACC_Q, val, REGS_ACC_Q, REG_LEN);
 			break;
 		default:
 			break;
@@ -692,11 +705,11 @@ void MKCpu::LogicOpAcc(unsigned short addr, int logop)
  */
 void MKCpu::CompareOpAcc(unsigned char val)
 {	
-	qRegs->SetBit(FLAGS_CARRY_Q, false);
-	qRegs->DECSC(val, REGS_ACC_Q, REG_LEN, FLAGS_OVERFLOW_Q, FLAGS_CARRY_Q);
-	qRegs->SetZeroFlag(REGS_ACC_Q, REG_LEN, FLAGS_ZERO_Q);
-	qRegs->SetSignFlag(REGS_ACC_Q + REG_LEN - 1, FLAGS_SIGN_Q);
-	qRegs->INC(val, REGS_ACC_Q, REG_LEN);
+	qReg->SetBit(FLAGS_CARRY_Q, false);
+	qReg->DECSC(val, REGS_ACC_Q, REG_LEN, FLAGS_OVERFLOW_Q, FLAGS_CARRY_Q);
+	qReg->SetZeroFlag(REGS_ACC_Q, REG_LEN, FLAGS_ZERO_Q);
+	qReg->SetSignFlag(REGS_ACC_Q + REG_LEN - 1, FLAGS_SIGN_Q);
+	qReg->INC(val, REGS_ACC_Q, REG_LEN);
 
 	SetFlag((mReg.Acc >= val), FLAGS_CARRY);
 	val = mReg.Acc - val;
@@ -715,11 +728,11 @@ void MKCpu::CompareOpAcc(unsigned char val)
  */
 void MKCpu::CompareOpIndX(unsigned char val)
 {	
-	qRegs->SetBit(FLAGS_CARRY_Q, false);
-	qRegs->DECSC(val, REGS_INDX_Q, REG_LEN, FLAGS_OVERFLOW_Q, FLAGS_CARRY_Q);
-	qRegs->SetZeroFlag(REGS_INDX_Q, REG_LEN, FLAGS_ZERO_Q);
-	qRegs->SetSignFlag(REGS_INDX_Q + REG_LEN - 1, FLAGS_SIGN_Q);
-	qRegs->INC(val, REGS_INDX_Q, REG_LEN);
+	qReg->SetBit(FLAGS_CARRY_Q, false);
+	qReg->DECSC(val, REGS_INDX_Q, REG_LEN, FLAGS_OVERFLOW_Q, FLAGS_CARRY_Q);
+	qReg->SetZeroFlag(REGS_INDX_Q, REG_LEN, FLAGS_ZERO_Q);
+	qReg->SetSignFlag(REGS_INDX_Q + REG_LEN - 1, FLAGS_SIGN_Q);
+	qReg->INC(val, REGS_INDX_Q, REG_LEN);
 
 	SetFlag((mReg.IndX >= val), FLAGS_CARRY);
 	val = mReg.IndX - val;
@@ -826,16 +839,16 @@ unsigned short MKCpu::Bcd2Num(unsigned char v)
 bool MKCpu::CheckFlag(unsigned char flag)
 {
 	unsigned char partFlag;
-	if (flag & FLAGS_CARRY) partFlag = qRegs->M(FLAGS_CARRY_Q) ? FLAGS_CARRY : 0;
+	if (flag & FLAGS_CARRY) partFlag = qReg->M(FLAGS_CARRY_Q) ? FLAGS_CARRY : 0;
 	mReg.Flags &= ~FLAGS_CARRY;
 	mReg.Flags |= partFlag;
-	if (flag & FLAGS_SIGN) partFlag = qRegs->M(FLAGS_SIGN_Q) ? FLAGS_SIGN : 0;
+	if (flag & FLAGS_SIGN) partFlag = qReg->M(FLAGS_SIGN_Q) ? FLAGS_SIGN : 0;
 	mReg.Flags &= ~FLAGS_SIGN;
 	mReg.Flags |= partFlag;
-	if (flag & FLAGS_ZERO) partFlag = qRegs->M(FLAGS_ZERO_Q) ? FLAGS_ZERO : 0;
+	if (flag & FLAGS_ZERO) partFlag = qReg->M(FLAGS_ZERO_Q) ? FLAGS_ZERO : 0;
 	mReg.Flags &= ~FLAGS_SIGN;
 	mReg.Flags |= partFlag;
-	if (flag & FLAGS_OVERFLOW) partFlag = qRegs->M(FLAGS_OVERFLOW_Q) ? FLAGS_SIGN : 0;
+	if (flag & FLAGS_OVERFLOW) partFlag = qReg->M(FLAGS_OVERFLOW_Q) ? FLAGS_SIGN : 0;
 	mReg.Flags &= ~FLAGS_SIGN;
 	mReg.Flags |= partFlag;
 	return ((mReg.Flags & flag) == flag);
@@ -864,15 +877,15 @@ void MKCpu::SetFlag(bool set, unsigned char flag)
 void MKCpu::SetFlagQ(bool set, unsigned char flag)
 {
 	if (set) {
-		if (flag & FLAGS_CARRY) qRegs->CLOR(FLAGS_CARRY_Q, true, FLAGS_CARRY_Q);
-		if (flag & FLAGS_ZERO) qRegs->CLOR(FLAGS_ZERO_Q, true, FLAGS_ZERO_Q);
-		if (flag & FLAGS_OVERFLOW) qRegs->CLOR(FLAGS_OVERFLOW_Q, true, FLAGS_OVERFLOW_Q);
-		if (flag & FLAGS_SIGN) qRegs->CLOR(FLAGS_SIGN_Q, true, FLAGS_SIGN_Q);
+		if (flag & FLAGS_CARRY) qReg->CLOR(FLAGS_CARRY_Q, true, FLAGS_CARRY_Q);
+		if (flag & FLAGS_ZERO) qReg->CLOR(FLAGS_ZERO_Q, true, FLAGS_ZERO_Q);
+		if (flag & FLAGS_OVERFLOW) qReg->CLOR(FLAGS_OVERFLOW_Q, true, FLAGS_OVERFLOW_Q);
+		if (flag & FLAGS_SIGN) qReg->CLOR(FLAGS_SIGN_Q, true, FLAGS_SIGN_Q);
 	} else {
-		if (flag & FLAGS_CARRY) qRegs->CLAND(FLAGS_CARRY_Q, false, FLAGS_CARRY_Q);
-		if (flag & FLAGS_ZERO) qRegs->CLAND(FLAGS_ZERO_Q, false, FLAGS_ZERO_Q);
-		if (flag & FLAGS_OVERFLOW) qRegs->CLAND(FLAGS_OVERFLOW_Q, false, FLAGS_OVERFLOW_Q);
-		if (flag & FLAGS_SIGN) qRegs->CLAND(FLAGS_SIGN_Q, false, FLAGS_SIGN_Q);
+		if (flag & FLAGS_CARRY) qReg->CLAND(FLAGS_CARRY_Q, false, FLAGS_CARRY_Q);
+		if (flag & FLAGS_ZERO) qReg->CLAND(FLAGS_ZERO_Q, false, FLAGS_ZERO_Q);
+		if (flag & FLAGS_OVERFLOW) qReg->CLAND(FLAGS_OVERFLOW_Q, false, FLAGS_OVERFLOW_Q);
+		if (flag & FLAGS_SIGN) qReg->CLAND(FLAGS_SIGN_Q, false, FLAGS_SIGN_Q);
 	}
 }
 
@@ -916,10 +929,10 @@ unsigned char MKCpu::AddWithCarry(unsigned char mem8)
 void MKCpu::AddWithCarryQ(unsigned char mem8)
 {
 	if (CheckFlag(FLAGS_DEC)) {
-		qRegs->INCBCDC(mem8, REGS_ACC_Q, REG_LEN, FLAGS_CARRY_Q);
+		qReg->INCBCDC(mem8, REGS_ACC_Q, REG_LEN, FLAGS_CARRY_Q);
 	}
 	else {
-		qRegs->INCSC(mem8, REGS_ACC_Q, REG_LEN, FLAGS_OVERFLOW_Q, FLAGS_CARRY_Q);
+		qReg->INCSC(mem8, REGS_ACC_Q, REG_LEN, FLAGS_OVERFLOW_Q, FLAGS_CARRY_Q);
 	}
 
 	SetFlagsRegQ(REGS_ACC_Q);
@@ -969,10 +982,10 @@ unsigned char MKCpu::SubWithCarry(unsigned char mem8)
 void MKCpu::SubWithCarryQ(unsigned char mem8)
 {
 	if (CheckFlag(FLAGS_DEC)) {
-		qRegs->DECBCDC(mem8, REGS_ACC_Q, REG_LEN, FLAGS_CARRY_Q);
+		qReg->DECBCDC(mem8, REGS_ACC_Q, REG_LEN, FLAGS_CARRY_Q);
 	}
 	else {
-		qRegs->DECSC(mem8, REGS_ACC_Q, REG_LEN, FLAGS_ZERO_Q, FLAGS_CARRY_Q);
+		qReg->DECSC(mem8, REGS_ACC_Q, REG_LEN, FLAGS_ZERO_Q, FLAGS_CARRY_Q);
 	}
 
 	SetFlagsRegQ(REGS_ACC_Q);
@@ -1034,7 +1047,7 @@ unsigned short MKCpu::GetAddrWithMode(int mode)
 		
 		//case ADDRMODE_ABA:
 		//	mReg.LastArg = tmp = GetArg16(0);
-		//	//mReg.IndX = qRegs->MReg8(8);
+		//	//mReg.IndX = qReg->MReg8(8);
 		//	//arg16 = tmp + mReg.IndX;
 		//	arg16 = tmp;
 		//	mReg.PageBoundary = PageBoundary(tmp, arg16 + 255);
@@ -1042,7 +1055,7 @@ unsigned short MKCpu::GetAddrWithMode(int mode)
 	
 		case ADDRMODE_ABX:
 			mReg.LastArg = tmp = GetArg16(0);
-			//mReg.IndX = qRegs->MReg8(8);
+			//mReg.IndX = qReg->MReg8(8);
 			//arg16 = tmp + mReg.IndX;
 			arg16 = tmp;
 			mReg.PageBoundary = PageBoundary(tmp, arg16 + 255);
@@ -1050,26 +1063,26 @@ unsigned short MKCpu::GetAddrWithMode(int mode)
 			
 		case ADDRMODE_ABY:
 			mReg.LastArg = tmp = GetArg16(0);
-			//mReg.IndY = qRegs->MReg8(16);
+			//mReg.IndY = qReg->MReg8(16);
 			arg16 = tmp + mReg.IndY;
 			mReg.PageBoundary = PageBoundary(tmp, arg16);
 			break;
 			
 		case ADDRMODE_ZPX:
 			mReg.LastArg = arg16 = mpMem->Peek8bit(mReg.PtrAddr++);
-			//mReg.IndX = qRegs->MReg8(8);
+			//mReg.IndX = qReg->MReg8(8);
 			//arg16 = (arg16 + mReg.IndX) & 0xFF;
 			break;
 			
 		case ADDRMODE_ZPY:
 			mReg.LastArg = arg16 = mpMem->Peek8bit(mReg.PtrAddr++);
-			//mReg.IndY = qRegs->MReg8(16);
+			//mReg.IndY = qReg->MReg8(16);
 			arg16 = (arg16 + mReg.IndY) & 0xFF;
 			break;
 			
 		case ADDRMODE_IZX:
 			mReg.LastArg = arg16 = mpMem->Peek8bit(mReg.PtrAddr++);
-			//mReg.IndX = qRegs->MReg8(8);
+			//mReg.IndX = qReg->MReg8(8);
 			//arg16 = (arg16 + mReg.IndX) & 0xFF;
 			arg16 = arg16 & 0xFF;
 			arg16 = mpMem->Peek16bit(arg16);			
@@ -1078,7 +1091,7 @@ unsigned short MKCpu::GetAddrWithMode(int mode)
 		case ADDRMODE_IZY:
 			mReg.LastArg = arg16 = mpMem->Peek8bit(mReg.PtrAddr++);
 			tmp = mpMem->Peek16bit(arg16);
-			//mReg.IndY = qRegs->MReg8(16);
+			//mReg.IndY = qReg->MReg8(16);
 			arg16 = tmp + mReg.IndY;
 			mReg.PageBoundary = PageBoundary(tmp, arg16);
 			break;
@@ -1349,7 +1362,7 @@ void MKCpu::OpCodeLdaIzx()
 	for (int i = 0; i < 256; i++) {
 		toLoad[i] = mpMem->Peek8bit((arg16 + i) & 0xFF);
 	}
-	mReg.Acc = qRegs->SuperposeReg8(REG_LEN, REGS_ACC_Q, toLoad);
+	mReg.Acc = qReg->SuperposeReg8(REG_LEN, REGS_ACC_Q, toLoad);
 	SetFlags(mReg.Acc);
 	SetFlagsRegQ(REGS_ACC_Q);
 }
@@ -1367,7 +1380,7 @@ void MKCpu::OpCodeLdaZp()
 	// LoaD Accumulator, Zero Page ($A5 arg : LDA arg ;arg=0..$FF),
 	// MEM=arg
 	mReg.Acc = mpMem->Peek8bit(GetAddrWithMode(ADDRMODE_ZP));
-	qRegs->SetReg(REGS_ACC_Q, REG_LEN, mReg.Acc);
+	qReg->SetReg(REGS_ACC_Q, REG_LEN, mReg.Acc);
 	SetFlags(mReg.Acc);
 	SetFlagsRegQ(REGS_ACC_Q);			
 }
@@ -1385,7 +1398,7 @@ void MKCpu::OpCodeLdaImm()
 	// LoaD Accumulator, Immediate ($A9 arg : LDA #arg ;arg=0..$FF),
 	// MEM=PC+1
 	mReg.Acc = mpMem->Peek8bit(GetAddrWithMode(ADDRMODE_IMM));
-	qRegs->SetReg(REGS_ACC_Q, REG_LEN, mReg.Acc);
+	qReg->SetReg(REGS_ACC_Q, REG_LEN, mReg.Acc);
 	mReg.LastArg = mReg.Acc;
 	SetFlags(mReg.Acc);
 	SetFlagsRegQ(REGS_ACC_Q);
@@ -1406,7 +1419,7 @@ void MKCpu::OpCodeLdaAbs()
 	// ;addr=0..$FFFF), MEM=addr
 	arg16 = GetAddrWithMode(ADDRMODE_ABS);
 	mReg.Acc = mpMem->Peek8bit(arg16);
-	qRegs->SetReg(REGS_ACC_Q, REG_LEN, mReg.Acc);
+	qReg->SetReg(REGS_ACC_Q, REG_LEN, mReg.Acc);
 	SetFlags(mReg.Acc);
 	SetFlagsRegQ(REGS_ACC_Q);
 }
@@ -1427,7 +1440,7 @@ void MKCpu::OpCodeLdaIzy()
 	arg16 = GetAddrWithMode(ADDRMODE_IZY);
 	if (mReg.PageBoundary) mReg.CyclesLeft++;
 	mReg.Acc = mpMem->Peek8bit(arg16);
-	qRegs->SetReg(REGS_ACC_Q, REG_LEN, mReg.Acc);
+	qReg->SetReg(REGS_ACC_Q, REG_LEN, mReg.Acc);
 	SetFlags(mReg.Acc);
 	SetFlagsRegQ(REGS_ACC_Q);
 }
@@ -1450,7 +1463,7 @@ void MKCpu::OpCodeLdaZpx()
 	for (int i = 0; i < 256; i++) {
 		toLoad[i] = mpMem->Peek8bit((arg16 + i) & 0xFF);
 	}
-	mReg.Acc = qRegs->SuperposeReg8(REGS_INDX_Q, REGS_ACC_Q, toLoad);
+	mReg.Acc = qReg->SuperposeReg8(REGS_INDX_Q, REGS_ACC_Q, toLoad);
 	SetFlags(mReg.Acc);
 	SetFlagsRegQ(REGS_ACC_Q);
 }
@@ -1471,7 +1484,7 @@ void MKCpu::OpCodeLdaAby()
 	arg16 = GetAddrWithMode(ADDRMODE_ABY);
 	if (mReg.PageBoundary) mReg.CyclesLeft++;
 	mReg.Acc = mpMem->Peek8bit(arg16);
-	qRegs->SetReg(REGS_ACC_Q, REG_LEN, mReg.Acc);
+	qReg->SetReg(REGS_ACC_Q, REG_LEN, mReg.Acc);
 	SetFlags(mReg.Acc);
 	SetFlagsRegQ(REGS_ACC_Q);
 }
@@ -1496,7 +1509,7 @@ void MKCpu::OpCodeLdaAby()
 	for (int i = 0; i < 256; i++) {
 		toLoad[i] = mpMem->Peek8bit(arg16 + i);
 	}
-	mReg.Acc = qRegs->SuperposeReg8(REGS_ACC_Q, REGS_ACC_Q, toLoad);
+	mReg.Acc = qReg->SuperposeReg8(REGS_ACC_Q, REGS_ACC_Q, toLoad);
 	SetFlags(mReg.Acc);
 	SetFlagsRegQ(REGS_ACC_Q);
 }*/
@@ -1520,7 +1533,7 @@ void MKCpu::OpCodeLdaAbx()
 	for (int i = 0; i < 256; i++) {
 		toLoad[i] = mpMem->Peek8bit(arg16 + i);
 	}
-	mReg.Acc = qRegs->SuperposeReg8(REGS_INDX_Q, REGS_ACC_Q, toLoad);
+	mReg.Acc = qReg->SuperposeReg8(REGS_INDX_Q, REGS_ACC_Q, toLoad);
 	SetFlags(mReg.Acc);
 	SetFlagsRegQ(REGS_ACC_Q);
 }
@@ -1539,7 +1552,7 @@ void MKCpu::OpCodeLdxImm()
 	// MEM=PC+1
 	unsigned char toX = mpMem->Peek8bit(GetAddrWithMode(ADDRMODE_IMM));
 	mReg.IndX = toX;
-	qRegs->SetReg(REGS_INDX_Q, REG_LEN, toX);
+	qReg->SetReg(REGS_INDX_Q, REG_LEN, toX);
 	mReg.LastArg = mReg.IndX;
 	SetFlags(mReg.IndX);
 	SetFlagsRegQ(REGS_INDX_Q);
@@ -1559,7 +1572,7 @@ void MKCpu::OpCodeLdxZp()
 	// MEM=arg
 	unsigned char toX = mpMem->Peek8bit(GetAddrWithMode(ADDRMODE_ZP));
 	mReg.IndX = toX;
-	qRegs->SetReg(REGS_INDX_Q, REG_LEN, toX);
+	qReg->SetReg(REGS_INDX_Q, REG_LEN, toX);
 	SetFlags(mReg.IndX);
 	SetFlagsRegQ(REGS_INDX_Q);
 }
@@ -1580,7 +1593,7 @@ void MKCpu::OpCodeLdxAbs()
 	arg16 = GetAddrWithMode(ADDRMODE_ABS);
 	unsigned char toX = mpMem->Peek8bit(arg16);
 	mReg.IndX = toX;
-	qRegs->SetReg(REGS_INDX_Q, REG_LEN, toX);
+	qReg->SetReg(REGS_INDX_Q, REG_LEN, toX);
 	SetFlags(mReg.IndX);
 	SetFlagsRegQ(REGS_INDX_Q);
 }
@@ -1601,7 +1614,7 @@ void MKCpu::OpCodeLdxZpy()
 	arg16 = GetAddrWithMode(ADDRMODE_ZPY);
 	unsigned char toX = mpMem->Peek8bit(arg16);
 	mReg.IndX = toX;
-	qRegs->SetReg(REGS_INDX_Q, REG_LEN, toX);
+	qReg->SetReg(REGS_INDX_Q, REG_LEN, toX);
 	SetFlags(mReg.IndX);
 	SetFlagsRegQ(REGS_INDX_Q);
 }
@@ -1623,7 +1636,7 @@ void MKCpu::OpCodeLdxAby()
 	if (mReg.PageBoundary) mReg.CyclesLeft++;
 	unsigned char toX = mpMem->Peek8bit(arg16);
 	mReg.IndX = toX;
-	qRegs->SetReg(REGS_INDX_Q, REG_LEN, toX);
+	qReg->SetReg(REGS_INDX_Q, REG_LEN, toX);
 	SetFlags(mReg.IndX);
 	SetFlagsRegQ(REGS_INDX_Q);
 }
@@ -1699,7 +1712,7 @@ void MKCpu::OpCodeLdyZpx()
 	// LoaD Y register, Zero Page Indexed, X
 	// ($B4 arg : LDY arg,X ;arg=0..$FF), MEM=arg+X
 	arg16 = GetAddrWithMode(ADDRMODE_ZPX);
-	mReg.IndX = qRegs->MReg8(8);
+	mReg.IndX = qReg->MReg8(8);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	mReg.IndY = mpMem->Peek8bit(arg16);
 	SetFlags(mReg.IndY);
@@ -1721,7 +1734,7 @@ void MKCpu::OpCodeLdyAbx()
 	// LoaD Y register, Absolute Indexed, X
 	// ($BC addrlo addrhi : LDY addr,X ;addr=0..$FFFF), MEM=addr+X
 	arg16 = GetAddrWithMode(ADDRMODE_ABX);
-	mReg.IndX = qRegs->MReg8(8);
+	mReg.IndX = qReg->MReg8(8);
 	arg16 += mReg.IndX;
 	if (mReg.PageBoundary) mReg.CyclesLeft++;
 	mReg.IndY = mpMem->Peek8bit(arg16);
@@ -1742,8 +1755,8 @@ void MKCpu::OpCodeTax()
 {
 	// Transfer A to X, Implied ($AA : TAX)
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->SetReg(REGS_INDX_Q, REG_LEN, 0);
-	qRegs->OR(REGS_ACC_Q, REGS_INDX_Q, REGS_INDX_Q, REG_LEN);
+	qReg->SetReg(REGS_INDX_Q, REG_LEN, 0);
+	qReg->OR(REGS_ACC_Q, REGS_INDX_Q, REGS_INDX_Q, REG_LEN);
 	mReg.IndX = mReg.Acc;
 	SetFlags(mReg.IndX);
 	SetFlagsRegQ(REGS_INDX_Q);
@@ -1761,7 +1774,7 @@ void MKCpu::OpCodeTay()
 {
 	// Transfer A to Y, Implied ($A8 : TAY)
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	mReg.Acc = qRegs->MReg8(REGS_ACC_Q);
+	mReg.Acc = qReg->MReg8(REGS_ACC_Q);
 	mReg.IndY = mReg.Acc;
 	SetFlags(mReg.IndY);
 	//SetFlagsRegQ(16);
@@ -1780,8 +1793,8 @@ void MKCpu::OpCodeTxa()
 {
 	// Transfer X to A, Implied ($8A : TXA)
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->SetReg(REGS_ACC_Q, REG_LEN, 0);
-	qRegs->OR(REGS_ACC_Q, REGS_INDX_Q, REGS_ACC_Q, REG_LEN);
+	qReg->SetReg(REGS_ACC_Q, REG_LEN, 0);
+	qReg->OR(REGS_ACC_Q, REGS_INDX_Q, REGS_ACC_Q, REG_LEN);
 	mReg.Acc = mReg.IndX;
 	SetFlags(mReg.Acc);
 	SetFlagsRegQ(REGS_ACC_Q);
@@ -1800,7 +1813,7 @@ void MKCpu::OpCodeTya()
 	// Transfer Y to A, Implied ($98 : TYA)
 	mReg.LastAddrMode = ADDRMODE_IMP;
 	mReg.Acc = mReg.IndY;
-	qRegs->SetReg(REGS_ACC_Q, REG_LEN, mReg.Acc);
+	qReg->SetReg(REGS_ACC_Q, REG_LEN, mReg.Acc);
 	SetFlags(mReg.Acc);
 	//SetFlagsRegQ(0);
 	SetFlagsRegQ(REGS_ACC_Q);
@@ -1819,7 +1832,7 @@ void MKCpu::OpCodeTsx()
 	// Transfer Stack ptr to X, Implied ($BA : TSX)
 	mReg.LastAddrMode = ADDRMODE_IMP;
 	mReg.IndX = mReg.PtrStack;
-	qRegs->SetReg(REGS_INDX_Q, REG_LEN, mReg.IndX);
+	qReg->SetReg(REGS_INDX_Q, REG_LEN, mReg.IndX);
 	SetFlags(mReg.IndX);
 	SetFlagsRegQ(REGS_INDX_Q);
 }
@@ -1838,7 +1851,7 @@ void MKCpu::OpCodeTxs()
 	mReg.LastAddrMode = ADDRMODE_IMP;
 	//mReg.PtrStack = mReg.IndX;
 
-	mReg.PtrStack = qRegs->MReg8(REGS_INDX_Q);
+	mReg.PtrStack = qReg->MReg8(REGS_INDX_Q);
 }
 
 /*
@@ -1855,9 +1868,9 @@ void MKCpu::OpCodeStaIzx()
 	// STore Accumulator, Indexed Indirect
 	// ($81 arg : STA (arg,X) ;arg=0..$FF), MEM=&(arg+X)
 	arg16 = GetAddrWithMode(ADDRMODE_IZX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
-	mReg.Acc = qRegs->MReg8(REGS_ACC_Q);
+	mReg.Acc = qReg->MReg8(REGS_ACC_Q);
 	mpMem->Poke8bit(arg16, mReg.Acc);
 }
 
@@ -1875,7 +1888,7 @@ void MKCpu::OpCodeStaZp()
 	// STore Accumulator, Zero Page ($85 arg : STA arg ;arg=0..$FF),
 	// MEM=arg
 	arg16 = GetAddrWithMode(ADDRMODE_ZP);
-	mReg.Acc = qRegs->MReg8(REGS_ACC_Q);
+	mReg.Acc = qReg->MReg8(REGS_ACC_Q);
 	mpMem->Poke8bit(arg16, mReg.Acc);
 }
 
@@ -1893,7 +1906,7 @@ void MKCpu::OpCodeStaAbs()
 	// STore Accumulator, Absolute
 	// ($8D addrlo addrhi : STA addr ;addr=0..$FFFF), MEM=addr
 	arg16 = GetAddrWithMode(ADDRMODE_ABS);
-	mReg.Acc = qRegs->MReg8(REGS_ACC_Q);
+	mReg.Acc = qReg->MReg8(REGS_ACC_Q);
 	mpMem->Poke8bit(arg16, mReg.Acc);
 }
 
@@ -1911,7 +1924,7 @@ void MKCpu::OpCodeStaIzy()
 	// STore Accumulator, Indirect Indexed
 	// ($91 arg : STA (arg),Y ;arg=0..$FF), MEM=&arg+Y
 	arg16 = GetAddrWithMode(ADDRMODE_IZY);
-	mReg.Acc = qRegs->MReg8(REGS_ACC_Q);
+	mReg.Acc = qReg->MReg8(REGS_ACC_Q);
 	mpMem->Poke8bit(arg16, mReg.Acc);
 }
 
@@ -1929,9 +1942,9 @@ void MKCpu::OpCodeStaZpx()
 	// STore Accumulator, Zero Page Indexed, X
 	// ($95 arg : STA arg,X ;arg=0..$FF), MEM=arg+X
 	arg16 = GetAddrWithMode(ADDRMODE_ZPX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
-	mReg.Acc = qRegs->MReg8(REGS_ACC_Q);
+	mReg.Acc = qReg->MReg8(REGS_ACC_Q);
 	mpMem->Poke8bit(arg16, mReg.Acc);
 }
 
@@ -1949,7 +1962,7 @@ void MKCpu::OpCodeStaAby()
 	// STore Accumulator, Absolute Indexed, Y
 	// ($99 addrlo addrhi : STA addr,Y ;addr=0..$FFFF), MEM=addr+Y
 	arg16 = GetAddrWithMode(ADDRMODE_ABY);
-	mReg.Acc = qRegs->MReg8(REGS_ACC_Q);
+	mReg.Acc = qReg->MReg8(REGS_ACC_Q);
 	mpMem->Poke8bit(arg16, mReg.Acc);
 }
 
@@ -1967,9 +1980,9 @@ void MKCpu::OpCodeStaAbx()
 	// STore Accumulator, Absolute Indexed, X
 	// ($9D addrlo addrhi : STA addr,X ;addr=0..$FFFF), MEM=addr+X
 	arg16 = GetAddrWithMode(ADDRMODE_ABX); 
-	mReg.IndX = qRegs->MReg8(REGS_ACC_Q);
+	mReg.IndX = qReg->MReg8(REGS_ACC_Q);
 	arg16 += mReg.IndX;
-	mReg.Acc = qRegs->MReg8(REGS_ACC_Q);
+	mReg.Acc = qReg->MReg8(REGS_ACC_Q);
 	mpMem->Poke8bit(arg16, mReg.Acc);
 }
 
@@ -1987,7 +2000,7 @@ void MKCpu::OpCodeStxZp()
 	// STore X register, Zero Page ($86 arg : STX arg ;arg=0..$FF),
 	// MEM=arg
 	arg16 = GetAddrWithMode(ADDRMODE_ZP);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	mpMem->Poke8bit(arg16, mReg.IndX);
 }
 
@@ -2005,7 +2018,7 @@ void MKCpu::OpCodeStxAbs()
 	// STore X register, Absolute
 	// ($8E addrlo addrhi : STX addr ;addr=0..$FFFF), MEM=addr
 	arg16 = GetAddrWithMode(ADDRMODE_ABS);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	mpMem->Poke8bit(arg16, mReg.IndX);
 }
 
@@ -2023,7 +2036,7 @@ void MKCpu::OpCodeStxZpy()
 	// STore X register, Zero Page Indexed, Y
 	// ($96 arg : STX arg,Y ;arg=0..$FF), MEM=arg+Y
 	arg16 = GetAddrWithMode(ADDRMODE_ZPY);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	mpMem->Poke8bit(arg16, mReg.IndX);
 }
 
@@ -2075,7 +2088,7 @@ void MKCpu::OpCodeStyZpx()
 	// STore Y register, Zero Page Indexed, X
 	// ($94 arg : STY arg,X ;arg=0..$FF), MEM=arg+X
 	arg16 = GetAddrWithMode(ADDRMODE_ZPX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	mpMem->Poke8bit(arg16, mReg.IndY);
 }
@@ -2297,7 +2310,7 @@ void MKCpu::OpCodeIncZpx()
 	// INCrement memory, Zero Page Indexed, X
 	// ($F6 arg : INC arg,X ;arg=0..$FF), MEM=arg+X	
 	arg16 = GetAddrWithMode(ADDRMODE_ZPX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	arg8 = mpMem->Peek8bit(arg16) + 1;
 	mpMem->Poke8bit(arg16, arg8);
@@ -2320,7 +2333,7 @@ void MKCpu::OpCodeIncAbx()
 	// INCrement memory, Absolute Indexed, X
 	// ($FE addrlo addrhi : INC addr,X ;addr=0..$FFFF), MEM=addr+X	
 	arg16 = GetAddrWithMode(ADDRMODE_ABX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 += mReg.IndX;
 	arg8 = mpMem->Peek8bit(arg16) + 1;
 	mpMem->Poke8bit(arg16, arg8);
@@ -2340,8 +2353,8 @@ void MKCpu::OpCodeInx()
 {
 	// INcrement X, Implied ($E8 : INX)
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->INCSC(1, REGS_INDX_Q, REG_LEN, FLAGS_OVERFLOW_Q, FLAGS_CARRY_Q);
-	qRegs->SetZeroFlag(REGS_INDX_Q, REG_LEN, FLAGS_ZERO_Q);
+	qReg->INCSC(1, REGS_INDX_Q, REG_LEN, FLAGS_OVERFLOW_Q, FLAGS_CARRY_Q);
+	qReg->SetZeroFlag(REGS_INDX_Q, REG_LEN, FLAGS_ZERO_Q);
 	mReg.IndX++;
 	SetFlags(mReg.IndX);
 	SetFlagsRegQ(REGS_INDX_Q);
@@ -2359,8 +2372,8 @@ void MKCpu::OpCodeDex()
 {
 	// DEcrement X, Implied ($CA : DEX)
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->DECSC(1, REGS_INDX_Q, REG_LEN, FLAGS_OVERFLOW_Q, FLAGS_CARRY_Q);
-	qRegs->SetZeroFlag(REGS_INDX_Q, REG_LEN, FLAGS_ZERO_Q);
+	qReg->DECSC(1, REGS_INDX_Q, REG_LEN, FLAGS_OVERFLOW_Q, FLAGS_CARRY_Q);
+	qReg->SetZeroFlag(REGS_INDX_Q, REG_LEN, FLAGS_ZERO_Q);
 	mReg.IndX--;
 	SetFlags(mReg.IndX);
 	SetFlagsRegQ(REGS_INDX_Q);
@@ -2446,7 +2459,7 @@ void MKCpu::OpCodeOraIzx()
 	// bitwise OR with Accumulator, Indexed Indirect
 	// ($01 arg : ORA (arg,X) ;arg=0..$FF), MEM=&(arg+X)
 	arg16 = GetAddrWithMode(ADDRMODE_IZX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	LogicOpAcc(arg16, LOGOP_OR);
 }
@@ -2533,7 +2546,7 @@ void MKCpu::OpCodeOraZpx()
 	// bitwise OR with Accumulator, Zero Page Indexed, X
 	// ($15 arg : ORA arg,X ;arg=0..$FF), MEM=arg+X
 	arg16 = GetAddrWithMode(ADDRMODE_ZPX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	LogicOpAcc(arg16, LOGOP_OR);
 }
@@ -2552,7 +2565,7 @@ void MKCpu::OpCodeOraAby()
 	// bitwise OR with Accumulator, Absolute Indexed, Y
 	// ($19 addrlo addrhi : ORA addr,Y ;addr=0..$FFFF), MEM=addr+Y
 	arg16 = GetAddrWithMode(ADDRMODE_ABY);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	if (mReg.PageBoundary) mReg.CyclesLeft++;
 	LogicOpAcc(arg16, LOGOP_OR);
@@ -2572,7 +2585,7 @@ void MKCpu::OpCodeOraAbx()
 	// bitwise OR with Accumulator, Absolute Indexed, X
 	// ($1D addrlo addrhi : ORA addr,X ;addr=0..$FFFF), MEM=addr+X
 	arg16 = GetAddrWithMode(ADDRMODE_ABX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 += mReg.IndX;
 	if (mReg.PageBoundary) mReg.CyclesLeft++;
 	LogicOpAcc(arg16, LOGOP_OR);
@@ -2653,7 +2666,7 @@ void MKCpu::OpCodeAslZpx()
 	// Arithmetic Shift Left, Zero Page Indexed, X
 	// ($16 arg : ASL arg,X ;arg=0..$FF), MEM=arg+X	
 	arg16 = GetAddrWithMode(ADDRMODE_ZPX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	arg8 = mpMem->Peek8bit(arg16);
 	SetFlagQ(((arg8 & FLAGS_SIGN) == FLAGS_SIGN), FLAGS_CARRY);
@@ -2676,7 +2689,7 @@ void MKCpu::OpCodeAslAbx()
 	// Arithmetic Shift Left, Absolute Indexed, X
 	// ($1E addrlo addrhi : ASL addr,X ;addr=0..$FFFF), MEM=addr+X		
 	arg16 = GetAddrWithMode(ADDRMODE_ABX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 += mReg.IndX;
 	arg8 = mpMem->Peek8bit(arg16);
 	SetFlagQ(((arg8 & FLAGS_SIGN) == FLAGS_SIGN), FLAGS_CARRY);
@@ -2729,7 +2742,7 @@ void MKCpu::OpCodeAndIzx()
 	// bitwise AND with accumulator, Indexed Indirect
 	// ($21 arg : AND (arg,X) ;arg=0..$FF), MEM=&(arg+X)
 	arg16 = GetAddrWithMode(ADDRMODE_IZX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	LogicOpAcc(arg16, LOGOP_AND);
 }
@@ -2816,7 +2829,7 @@ void MKCpu::OpCodeAndZpx()
 	// bitwise AND with accumulator, Zero Page Indexed, X
 	// ($35 arg : AND arg,X ;arg=0..$FF), MEM=arg+X
 	arg16 = GetAddrWithMode(ADDRMODE_ZPX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	LogicOpAcc(arg16, LOGOP_AND);
 }
@@ -2853,7 +2866,7 @@ void MKCpu::OpCodeAndAbx()
 	// bitwise AND with accumulator, Absolute Indexed, X
 	// ($3D addrlo addrhi : AND addr,X ;addr=0..$FFFF), MEM=addr+X
 	arg16 = GetAddrWithMode(ADDRMODE_ABX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 += mReg.IndX;
 	if (mReg.PageBoundary) mReg.CyclesLeft++;
 	LogicOpAcc(arg16, LOGOP_AND);
@@ -2879,7 +2892,7 @@ void MKCpu::OpCodeBitZp()
 	SetFlagQ((arg8 & FLAGS_OVERFLOW) == FLAGS_OVERFLOW, FLAGS_OVERFLOW);
 	SetFlagQ((arg8 & FLAGS_SIGN) == FLAGS_SIGN, FLAGS_SIGN);
 	//arg8 &= mReg.Acc;
-	mReg.Acc = qRegs->MReg8(REGS_ACC_Q);
+	mReg.Acc = qReg->MReg8(REGS_ACC_Q);
 	arg8 = (mpMem->Peek8bit(arg16)) & mReg.Acc;
 	SetFlag((arg8 == 0), FLAGS_ZERO);
 	SetFlagQ((arg8 == 0), FLAGS_ZERO);
@@ -2906,7 +2919,7 @@ void MKCpu::OpCodeBitAbs()
 	SetFlagQ((arg8 & FLAGS_OVERFLOW) == FLAGS_OVERFLOW, FLAGS_OVERFLOW);
 	SetFlagQ((arg8 & FLAGS_SIGN) == FLAGS_SIGN, FLAGS_SIGN);		
 	//arg8 &= mReg.Acc;
-	mReg.Acc = qRegs->MReg8(REGS_ACC_Q);
+	mReg.Acc = qReg->MReg8(REGS_ACC_Q);
 	arg8 = (mpMem->Peek8bit(arg16)) & mReg.Acc;
 	SetFlag((arg8 == 0), FLAGS_ZERO);
 	SetFlagQ((arg8 == 0), FLAGS_ZERO);
@@ -2982,7 +2995,7 @@ void MKCpu::OpCodeRolZpx()
 	// ROtate Left, Zero Page Indexed, X
 	// ($36 arg : ROL arg,X ;arg=0..$FF), MEM=arg+X		
 	arg16 = GetAddrWithMode(ADDRMODE_ZPX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	arg8 = mpMem->Peek8bit(arg16);
 	arg8 = RotateLeft(arg8);
@@ -3004,7 +3017,7 @@ void MKCpu::OpCodeRolAbx()
 	// ROtate Left, Absolute Indexed, X
 	// ($3E addrlo addrhi : ROL addr,X ;addr=0..$FFFF), MEM=addr+X
 	arg16 = GetAddrWithMode(ADDRMODE_ABX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 += mReg.IndX;
 	arg8 = mpMem->Peek8bit(arg16);
 	arg8 = RotateLeft(arg8);
@@ -3047,7 +3060,7 @@ void MKCpu::OpCodePha()
 	mReg.LastAddrMode = ADDRMODE_IMP;
 	arg16 = 0x100;
 	arg16 += mReg.PtrStack--;
-	mReg.Acc = qRegs->MReg8(REGS_ACC_Q);
+	mReg.Acc = qReg->MReg8(REGS_ACC_Q);
 	mpMem->Poke8bit(arg16, mReg.Acc);
 }
 
@@ -3086,7 +3099,7 @@ void MKCpu::OpCodePla()
 	arg16 = 0x100;
 	arg16 += ++mReg.PtrStack;
 	mReg.Acc = mpMem->Peek8bit(arg16);
-	qRegs->SetReg(REGS_ACC_Q, REG_LEN, mReg.Acc);
+	qReg->SetReg(REGS_ACC_Q, REG_LEN, mReg.Acc);
 	SetFlags(mReg.Acc);
 	SetFlagsRegQ(REGS_ACC_Q);
 }
@@ -3094,48 +3107,31 @@ void MKCpu::OpCodePla()
 /*
  *--------------------------------------------------------------------
  * Method:		OpCodeClo()
- * Purpose:		Clear oracle flag, IMPlied addressing mode.
+ * Purpose:		Clear quantum mode flag, IMPlied addressing mode.
  * Arguments:		n/a
  * Returns:		n/a
  *--------------------------------------------------------------------
  */
-void MKCpu::OpCodeClo()
+void MKCpu::OpCodeClq()
 {
 	// CLear Oracle, Implied ($1f : CLO)
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	SetFlag(false, FLAGS_ORACLE);
-	SetFlagQ(false, FLAGS_ORACLE);
-}
-
-/*
- *--------------------------------------------------------------------
- * Method:		OpCodeHao()
- * Purpose:		Hadamard on oracle flag, IMPlied addressing mode.
- * Arguments:		n/a
- * Returns:		n/a
- *--------------------------------------------------------------------
- */
-void MKCpu::OpCodeHao()
-{
-	// Hadamard Carry, Implied ($07 : HAO)
-	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->H(FLAGS_ORACLE_Q);
+	SetFlag(false, FLAGS_QUANTUM);
 }
 
 /*
  *--------------------------------------------------------------------
  * Method:		OpCodeSEO()
- * Purpose:		SEt Oracle flag, IMPlied addressing mode.
+ * Purpose:		SEt quantum mode flag, IMPlied addressing mode.
  * Arguments:		n/a
  * Returns:		n/a
  *--------------------------------------------------------------------
  */
-void MKCpu::OpCodeSeo()
+void MKCpu::OpCodeSeq()
 {
 	// SEear Oracle, Implied ($3f : SEO)
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	SetFlag(true, FLAGS_ORACLE);
-	SetFlagQ(true, FLAGS_ORACLE);
+	SetFlag(true, FLAGS_QUANTUM);
 }
 
 /*
@@ -3166,7 +3162,7 @@ void MKCpu::OpCodeHac()
 {
 	// Hadamard Carry, Implied ($18 : CLC)
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->H(FLAGS_CARRY_Q);
+	qReg->H(FLAGS_CARRY_Q);
 }
 
 /*
@@ -3219,7 +3215,7 @@ void MKCpu::OpCodeClv()
 
 /*
  *--------------------------------------------------------------------
- * Method:		OpCodeHac()
+ * Method:		OpCodeHav()
  * Purpose:		Hadamard on overflow flag, IMPlied addressing mode.
  * Arguments:	n/a
  * Returns:		n/a
@@ -3229,7 +3225,101 @@ void MKCpu::OpCodeHav()
 {
 	// Hadamard overflow, Implied ($18 : CLC)
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->H(FLAGS_OVERFLOW_Q);
+	qReg->H(FLAGS_OVERFLOW_Q);
+}
+
+/*
+ *--------------------------------------------------------------------
+ * Method:		OpCodeHas()
+ * Purpose:		Hadamard on sign flag, IMPlied addressing mode.
+ * Arguments:	n/a
+ * Returns:		n/a
+ *--------------------------------------------------------------------
+ */
+void MKCpu::OpCodeHas()
+{
+	// Hadamard overflow, Implied ($18 : CLC)
+	mReg.LastAddrMode = ADDRMODE_IMP;
+	qReg->H(FLAGS_SIGN_Q);
+}
+
+/*
+ *--------------------------------------------------------------------
+ * Method:		OpCodeHaz()
+ * Purpose:		Hadamard on zero flag, IMPlied addressing mode.
+ * Arguments:	n/a
+ * Returns:		n/a
+ *--------------------------------------------------------------------
+ */
+void MKCpu::OpCodeHaz()
+{
+	// Hadamard overflow, Implied ($18 : CLC)
+	mReg.LastAddrMode = ADDRMODE_IMP;
+	qReg->H(FLAGS_ZERO_Q);
+}
+
+/*
+ *--------------------------------------------------------------------
+ * Method:		OpCodeQxZero()
+ * Purpose:		X operator on zero flag qubit, IMPlied addressing mode.
+ * Arguments:	n/a
+ * Returns:		n/a
+ *--------------------------------------------------------------------
+ */
+void MKCpu::OpCodeQxZero()
+{
+	// Hadamard overflow, Implied ($18 : CLC)
+	mReg.LastAddrMode = ADDRMODE_IMP;
+	qReg->X(FLAGS_ZERO_Q);
+	if (mReg.Flags & FLAGS_QUANTUM) mReg.Flags ^= FLAGS_ZERO;
+}
+
+/*
+ *--------------------------------------------------------------------
+ * Method:		OpCodeQxSign()
+ * Purpose:		X operator on sign flag qubit, IMPlied addressing mode.
+ * Arguments:	n/a
+ * Returns:		n/a
+ *--------------------------------------------------------------------
+ */
+void MKCpu::OpCodeQxSign()
+{
+	// Hadamard overflow, Implied ($18 : CLC)
+	mReg.LastAddrMode = ADDRMODE_IMP;
+	qReg->X(FLAGS_SIGN_Q);
+	if (mReg.Flags & FLAGS_QUANTUM) mReg.Flags ^= FLAGS_SIGN;
+}
+
+/*
+ *--------------------------------------------------------------------
+ * Method:		OpCodeQxCarry()
+ * Purpose:		X operator on carry flag qubit, IMPlied addressing mode.
+ * Arguments:	n/a
+ * Returns:		n/a
+ *--------------------------------------------------------------------
+ */
+void MKCpu::OpCodeQxCarry()
+{
+	// Hadamard overflow, Implied ($18 : CLC)
+	mReg.LastAddrMode = ADDRMODE_IMP;
+	qReg->X(FLAGS_CARRY_Q);
+	if (mReg.Flags & FLAGS_QUANTUM) mReg.Flags ^= FLAGS_CARRY;
+}
+
+/*
+ *--------------------------------------------------------------------
+ * Method:		OpCodeQxOver()
+ * Purpose:		X operator on overflow flag qubit, IMPlied addressing mode.
+ * Arguments:	n/a
+ * Returns:		n/a
+ *--------------------------------------------------------------------
+ */
+void MKCpu::OpCodeQxOver()
+{
+	// Hadamard overflow, Implied ($18 : CLC)
+	mReg.LastAddrMode = ADDRMODE_IMP;
+	qReg->X(FLAGS_OVERFLOW_Q);
+	if (mReg.Flags & FLAGS_QUANTUM) mReg.Flags ^= FLAGS_OVERFLOW;
 }
 
 /*
@@ -3351,7 +3441,7 @@ void MKCpu::OpCodeEorIzx()
 	// bitwise Exclusive OR, Indexed Indirect
 	// ($41 arg : EOR (arg,X) ;arg=0..$FF), MEM=&(arg+X)
 	arg16 = GetAddrWithMode(ADDRMODE_IZX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	LogicOpAcc(arg16, LOGOP_EOR);
 }
@@ -3438,7 +3528,7 @@ void MKCpu::OpCodeEorZpx()
 	// bitwise Exclusive OR, Zero Page Indexed, X
 	// ($55 arg : EOR arg,X ;arg=0..$FF), MEM=arg+X
 	arg16 = GetAddrWithMode(ADDRMODE_ZPX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	LogicOpAcc(arg16, LOGOP_EOR);
 }
@@ -3475,7 +3565,7 @@ void MKCpu::OpCodeEorAbx()
 	// bitwise Exclusive OR, Absolute Indexed, X
 	// ($5D addrlo addrhi : EOR addr,X ;addr=0..$FFFF), MEM=addr+X
 	arg16 = GetAddrWithMode(ADDRMODE_ABX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 += mReg.IndX;
 	if (mReg.PageBoundary) mReg.CyclesLeft++;
 	LogicOpAcc(arg16, LOGOP_EOR);
@@ -3554,7 +3644,7 @@ void MKCpu::OpCodeLsrZpx()
 	// Logical Shift Right, Zero Page Indexed, X
 	// ($56 arg : LSR arg,X ;arg=0..$FF), MEM=arg+X
 	arg16 = GetAddrWithMode(ADDRMODE_ZPX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	arg8 = mpMem->Peek8bit(arg16);
 	SetFlagQ(((arg8 & 0x01) == 0x01), FLAGS_CARRY);
@@ -3577,7 +3667,7 @@ void MKCpu::OpCodeLsrAbx()
 	// Logical Shift Right, Absolute Indexed, X
 	// ($5E addrlo addrhi : LSR addr,X ;addr=0..$FFFF), MEM=addr+X
 	arg16 = GetAddrWithMode(ADDRMODE_ABX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 += mReg.IndX;
 	arg8 = mpMem->Peek8bit(arg16);
 	SetFlagQ(((arg8 & 0x01) == 0x01), FLAGS_CARRY);
@@ -3599,7 +3689,7 @@ void MKCpu::OpCodeAdcIzx()
 	// ADd with Carry, Indexed Indirect
 	// ($61 arg : ADC (arg,X) ;arg=0..$FF), MEM=&(arg+X)
 	arg16 = GetAddrWithMode(ADDRMODE_IZX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	unsigned char toAdd = mpMem->Peek8bit(arg16);
 	AddWithCarry(toAdd);
@@ -3700,7 +3790,7 @@ void MKCpu::OpCodeAdcZpx()
 	// ADd with Carry, Zero Page Indexed, X
 	// ($75 arg : ADC arg,X ;arg=0..$FF), MEM=arg+X
 	arg16 = GetAddrWithMode(ADDRMODE_ZPX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	unsigned char toAdd = mpMem->Peek8bit(arg16);
 	AddWithCarry(toAdd);
@@ -3743,7 +3833,7 @@ void MKCpu::OpCodeAdcAbx()
 	// ADd with Carry, Absolute Indexed, X
 	// ($7D addrlo addrhi : ADC addr,X ;addr=0..$FFFF), MEM=addr+X
 	arg16 = GetAddrWithMode(ADDRMODE_ABX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 += mReg.IndX;
 	if (mReg.PageBoundary) mReg.CyclesLeft++;
 	unsigned char toAdd = mpMem->Peek8bit(arg16);
@@ -3820,7 +3910,7 @@ void MKCpu::OpCodeRorZpx()
 	// ROtate Right, Zero Page Indexed, X
 	// ($76 arg : ROR arg,X ;arg=0..$FF), MEM=arg+X
 	arg16 = GetAddrWithMode(ADDRMODE_ZPX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	arg8 = mpMem->Peek8bit(arg16);
 	mpMem->Poke8bit(arg16, RotateRight(arg8));		
@@ -3841,7 +3931,7 @@ void MKCpu::OpCodeRorAbx()
 	// ROtate Right, Absolute Indexed, X
 	// ($7E addrlo addrhi : ROR addr,X ;addr=0..$FFFF), MEM=addr+X
 	arg16 = GetAddrWithMode(ADDRMODE_ABX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 += mReg.IndX;
 	arg8 = mpMem->Peek8bit(arg16);
 	mpMem->Poke8bit(arg16, RotateRight(arg8));
@@ -3928,7 +4018,7 @@ void MKCpu::OpCodeCmpIzx()
 	// CoMPare accumulator, Indexed Indirect
 	// ($A1 arg : LDA (arg,X) ;arg=0..$FF), MEM=&(arg+X)
 	arg16 = GetAddrWithMode(ADDRMODE_IZX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	arg8 = mpMem->Peek8bit(arg16);
 	CompareOpAcc(arg8);
@@ -4024,7 +4114,7 @@ void MKCpu::OpCodeCmpZpx()
 	// CoMPare accumulator, Zero Page Indexed, X
 	// ($D5 arg : CMP arg,X ;arg=0..$FF), MEM=arg+X
 	arg16 = GetAddrWithMode(ADDRMODE_ZPX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	arg8 = mpMem->Peek8bit(arg16);
 	CompareOpAcc(arg8);
@@ -4065,7 +4155,7 @@ void MKCpu::OpCodeCmpAbx()
 	// CoMPare accumulator, Absolute Indexed, X
 	// ($DD addrlo addrhi : CMP addr,X ;addr=0..$FFFF), MEM=addr+X
 	arg16 = GetAddrWithMode(ADDRMODE_ABX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 += mReg.IndX;
 	if (mReg.PageBoundary) mReg.CyclesLeft++;
 	arg8 = mpMem->Peek8bit(arg16);
@@ -4129,7 +4219,7 @@ void MKCpu::OpCodeDecZpx()
 	// DECrement memory, Zero Page Indexed, X
 	// ($D6 arg : DEC arg,X ;arg=0..$FF), MEM=arg+X
 	arg16 = GetAddrWithMode(ADDRMODE_ZPX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	arg8 = mpMem->Peek8bit(arg16) - 1;
 	mpMem->Poke8bit(arg16, arg8);
@@ -4152,7 +4242,7 @@ void MKCpu::OpCodeDecAbx()
 	// DECrement memory, Absolute Indexed, X
 	// ($DE addrlo addrhi : DEC addr,X ;addr=0..$FFFF), MEM=addr+X
 	arg16 = GetAddrWithMode(ADDRMODE_ABX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 += mReg.IndX;
 	arg8 = mpMem->Peek8bit(arg16) - 1;
 	mpMem->Poke8bit(arg16, arg8);
@@ -4269,7 +4359,7 @@ void MKCpu::OpCodeSbcIzx()
 	// SuBtract with Carry, Indexed Indirect
 	// ($E1 arg : SBC (arg,X) ;arg=0..$FF), MEM=&(arg+X)
 	arg16 = GetAddrWithMode(ADDRMODE_IZX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	unsigned char toSub = mpMem->Peek8bit(arg16);
 	SubWithCarry(toSub);
@@ -4312,7 +4402,7 @@ void MKCpu::OpCodeSbcZpx()
 	// SuBtract with Carry, Zero Page Indexed, X
 	// ($F5 arg : SBC arg,X ;arg=0..$FF), MEM=arg+X
 	arg16 = GetAddrWithMode(ADDRMODE_ZPX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 = (arg16 + mReg.IndX) & 0xFF;
 	unsigned char toSub = mpMem->Peek8bit(arg16);
 	SubWithCarry(toSub);
@@ -4355,7 +4445,7 @@ void MKCpu::OpCodeSbcAbx()
 	// SuBtract with Carry, Absolute Indexed, X
 	// ($FD addrlo addrhi : SBC addr,X ;addr=0..$FFFF), MEM=addr+X
 	arg16 = GetAddrWithMode(ADDRMODE_ABX);
-	mReg.IndX = qRegs->MReg8(REGS_INDX_Q);
+	mReg.IndX = qReg->MReg8(REGS_INDX_Q);
 	arg16 += mReg.IndX;
 	if (mReg.PageBoundary) mReg.CyclesLeft++;
 	unsigned char toSub = mpMem->Peek8bit(arg16);
@@ -4406,7 +4496,7 @@ void MKCpu::OpCodeDud()
 void MKCpu::OpCodeHadA()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->H(REGS_ACC_Q, REG_LEN);
+	qReg->H(REGS_ACC_Q, REG_LEN);
 	mReg.Acc = RotateClassical(mReg.Acc);
 	SetFlagsRegQ(REGS_ACC_Q);
 	SetFlags(mReg.Acc);
@@ -4423,7 +4513,7 @@ void MKCpu::OpCodeHadA()
 void MKCpu::OpCodeHadX()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->H(REGS_INDX_Q, REG_LEN);
+	qReg->H(REGS_INDX_Q, REG_LEN);
 	mReg.IndX = RotateClassical(mReg.IndX);
 	SetFlagsRegQ(REGS_INDX_Q);
 	SetFlags(mReg.IndX);
@@ -4440,7 +4530,7 @@ void MKCpu::OpCodeHadX()
 void MKCpu::OpCodeXA()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->X(REGS_ACC_Q, REG_LEN);
+	qReg->X(REGS_ACC_Q, REG_LEN);
 	SetFlagsRegQ(REGS_ACC_Q);
 }
 
@@ -4455,24 +4545,8 @@ void MKCpu::OpCodeXA()
 void MKCpu::OpCodeXX()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->X(REGS_INDX_Q, REG_LEN);
+	qReg->X(REGS_INDX_Q, REG_LEN);
 	SetFlagsRegQ(REGS_INDX_Q);
-}
-
-/*
- *--------------------------------------------------------------------
- * Method:		OpCodeXO()
- * Purpose:		Apply Pauli X to the Oracle Flag
- * Arguments:		n/a
- * Returns:		n/a
- *--------------------------------------------------------------------
- */
-void MKCpu::OpCodeXO()
-{
-	mReg.LastAddrMode = ADDRMODE_IMP;
-	if (mReg.Flags & FLAGS_ORACLE) mReg.Flags &= (~FLAGS_ORACLE) & 0xFF;
-	else mReg.Flags |= FLAGS_ORACLE;
-	qRegs->X(FLAGS_ORACLE_Q);
 }
 
 /*
@@ -4486,7 +4560,7 @@ void MKCpu::OpCodeXO()
 void MKCpu::OpCodeYA()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->Y(REGS_ACC_Q, REG_LEN);
+	qReg->Y(REGS_ACC_Q, REG_LEN);
 	SetFlagsRegQ(REGS_ACC_Q);
 }
 
@@ -4501,7 +4575,7 @@ void MKCpu::OpCodeYA()
 void MKCpu::OpCodeYX()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->Y(REGS_INDX_Q, REG_LEN);
+	qReg->Y(REGS_INDX_Q, REG_LEN);
 	SetFlagsRegQ(REGS_INDX_Q);
 }
 
@@ -4516,7 +4590,7 @@ void MKCpu::OpCodeYX()
 void MKCpu::OpCodeZA()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->Z(REGS_ACC_Q, REG_LEN);
+	qReg->Z(REGS_ACC_Q, REG_LEN);
 	SetFlagsRegQ(REGS_ACC_Q);
 }
 
@@ -4531,7 +4605,7 @@ void MKCpu::OpCodeZA()
 void MKCpu::OpCodeZX()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->Z(REGS_INDX_Q, REG_LEN);
+	qReg->Z(REGS_INDX_Q, REG_LEN);
 	SetFlagsRegQ(REGS_INDX_Q);
 }
 
@@ -4546,7 +4620,7 @@ void MKCpu::OpCodeZX()
 void MKCpu::OpCodeR1A()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->R1(M_PI / 2.0, REGS_ACC_Q, REG_LEN);
+	qReg->R1(M_PI / 2.0, REGS_ACC_Q, REG_LEN);
 	SetFlagsRegQ(REGS_ACC_Q);
 }
 
@@ -4561,7 +4635,7 @@ void MKCpu::OpCodeR1A()
 void MKCpu::OpCodeR1X()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->R1(M_PI / 2.0, REGS_INDX_Q, REG_LEN);
+	qReg->R1(M_PI / 2.0, REGS_INDX_Q, REG_LEN);
 	SetFlagsRegQ(REGS_INDX_Q);
 }
 
@@ -4576,7 +4650,7 @@ void MKCpu::OpCodeR1X()
 void MKCpu::OpCodeRXA()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->RX(M_PI / 2.0, REGS_ACC_Q, REG_LEN);
+	qReg->RX(M_PI / 2.0, REGS_ACC_Q, REG_LEN);
 	mReg.Acc = RotateClassical(mReg.Acc);
 	SetFlagsRegQ(REGS_ACC_Q);
 	SetFlags(mReg.Acc);
@@ -4593,7 +4667,7 @@ void MKCpu::OpCodeRXA()
 void MKCpu::OpCodeRXX()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->RX(M_PI / 2.0, REGS_INDX_Q, REG_LEN);
+	qReg->RX(M_PI / 2.0, REGS_INDX_Q, REG_LEN);
 	mReg.IndX = RotateClassical(mReg.IndX);
 	SetFlagsRegQ(REGS_INDX_Q);
 	SetFlags(mReg.IndX);
@@ -4610,7 +4684,7 @@ void MKCpu::OpCodeRXX()
 void MKCpu::OpCodeRYA()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->RY(M_PI / 2.0, REGS_ACC_Q, REG_LEN);
+	qReg->RY(M_PI / 2.0, REGS_ACC_Q, REG_LEN);
 	mReg.Acc = RotateClassical(mReg.Acc);
 	SetFlagsRegQ(REGS_ACC_Q);
 	SetFlags(mReg.Acc);
@@ -4627,7 +4701,7 @@ void MKCpu::OpCodeRYA()
 void MKCpu::OpCodeRYX()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->RY(M_PI / 2.0, REGS_INDX_Q, REG_LEN);
+	qReg->RY(M_PI / 2.0, REGS_INDX_Q, REG_LEN);
 	mReg.IndX = RotateClassical(mReg.IndX);
 	SetFlagsRegQ(REGS_INDX_Q);
 	SetFlags(mReg.IndX);
@@ -4644,7 +4718,7 @@ void MKCpu::OpCodeRYX()
 void MKCpu::OpCodeRZA()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->RZ(M_PI / 2.0, REGS_ACC_Q, REG_LEN);
+	qReg->RZ(M_PI / 2.0, REGS_ACC_Q, REG_LEN);
 	mReg.Acc = RotateClassical(mReg.Acc);
 	SetFlagsRegQ(REGS_ACC_Q);
 	SetFlags(mReg.Acc);
@@ -4661,7 +4735,7 @@ void MKCpu::OpCodeRZA()
 void MKCpu::OpCodeRZX()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->RZ(M_PI / 2.0, REGS_INDX_Q, REG_LEN);
+	qReg->RZ(M_PI / 2.0, REGS_INDX_Q, REG_LEN);
 	mReg.IndX = RotateClassical(mReg.IndX);
 	SetFlagsRegQ(REGS_INDX_Q);
 	SetFlags(mReg.IndX);
@@ -4678,7 +4752,7 @@ void MKCpu::OpCodeRZX()
 void MKCpu::OpCodeFTA()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->QFT(REGS_ACC_Q, REG_LEN);
+	qReg->QFT(REGS_ACC_Q, REG_LEN);
 	SetFlagsRegQ(REGS_ACC_Q);
 	//TODO: Implement classical Fourier transform, here.
 }
@@ -4694,81 +4768,9 @@ void MKCpu::OpCodeFTA()
 void MKCpu::OpCodeFTX()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
-	qRegs->QFT(REGS_INDX_Q, REG_LEN);
+	qReg->QFT(REGS_INDX_Q, REG_LEN);
 	SetFlagsRegQ(REGS_INDX_Q);
 	//TODO: Implement classical Fourier transform, here.
-}
-
-/*
- *--------------------------------------------------------------------
- * Method:		OpCodeOcnZero()
- * Purpose:		CCNOT(Zero, Oracle)
- * Arguments:		n/a
- * Returns:		n/a
- *--------------------------------------------------------------------
- */
-void MKCpu::OpCodeOcnZero()
-{
-	mReg.LastAddrMode = ADDRMODE_IMP;
-	if (mReg.Flags & FLAGS_ZERO) {
-		if (mReg.Flags & FLAGS_ORACLE) mReg.Flags &= (~FLAGS_ORACLE) & 0xFF;
-		else mReg.Flags |= FLAGS_ORACLE;
-	}
-	qRegs->CNOT(FLAGS_ZERO_Q, FLAGS_ORACLE_Q);
-}
-
-/*
- *--------------------------------------------------------------------
- * Method:		OpCodeOcnSign()
- * Purpose:		CCNOT(Sign, Oracle)
- * Arguments:		n/a
- * Returns:		n/a
- *--------------------------------------------------------------------
- */
-void MKCpu::OpCodeOcnSign()
-{
-	mReg.LastAddrMode = ADDRMODE_IMP;
-	if (mReg.Flags & FLAGS_SIGN) {
-		if (mReg.Flags & FLAGS_ORACLE) mReg.Flags &= (~FLAGS_ORACLE) & 0xFF;
-		else mReg.Flags |= FLAGS_ORACLE;
-	}
-	qRegs->CNOT(FLAGS_SIGN_Q, FLAGS_ORACLE_Q);
-}
-
-/*
- *--------------------------------------------------------------------
- * Method:		OpCodeOcnCarry()
- * Purpose:		CCNOT(Carry, Oracle)
- * Arguments:		n/a
- * Returns:		n/a
- *--------------------------------------------------------------------
- */
-void MKCpu::OpCodeOcnCarry()
-{
-	mReg.LastAddrMode = ADDRMODE_IMP;
-	if (mReg.Flags & FLAGS_CARRY) {
-		if (mReg.Flags & FLAGS_ORACLE) mReg.Flags &= (~FLAGS_ORACLE) & 0xFF;
-		else mReg.Flags |= FLAGS_ORACLE;
-	}
-	qRegs->CNOT(FLAGS_CARRY_Q, FLAGS_ORACLE_Q);
-}
-
-/*
- *--------------------------------------------------------------------
- * Method:		OpCodeOcnOver()
- * Purpose:		CCNOT(Over, Oracle)
- * Arguments:		n/a
- * Returns:		n/a
- *--------------------------------------------------------------------
- */
-void MKCpu::OpCodeOcnOver()
-{
-	mReg.LastAddrMode = ADDRMODE_IMP;
-	if (mReg.Flags & FLAGS_OVERFLOW) {
-		if (mReg.Flags & FLAGS_ORACLE) mReg.Flags &= (~FLAGS_ORACLE) & 0xFF;
-		else mReg.Flags |= FLAGS_ORACLE;
-	}
-	qRegs->CNOT(FLAGS_OVERFLOW_Q, FLAGS_ORACLE_Q);
 }
 
 /*
@@ -4977,9 +4979,9 @@ void	MKCpu::Reset()
 void MKCpu::SetRegs(Regs r)
 {
 	mReg.Acc = r.Acc;
-	qRegs->SetReg(REGS_ACC_Q, REG_LEN, r.Acc);
+	qReg->SetReg(REGS_ACC_Q, REG_LEN, r.Acc);
 	mReg.IndX = r.IndX;
-	qRegs->SetReg(REGS_INDX_Q, REG_LEN, r.IndX);
+	qReg->SetReg(REGS_INDX_Q, REG_LEN, r.IndX);
 	mReg.IndY = r.IndY;
 	mReg.PtrAddr = r.PtrAddr;
 	mReg.PtrStack = r.PtrStack;

--- a/MKCpu.cpp
+++ b/MKCpu.cpp
@@ -36,7 +36,7 @@
 #include <string.h>
 #include "MKCpu.h"
 #include "MKGenException.h"
-#include <iostream>
+//#include <iostream>
 
 #if ENABLE_OPENCL
 Qrack::CoherentUnitEngine coherentUnitEngine = Qrack::COHERENT_UNIT_ENGINE_OPENCL;
@@ -703,7 +703,6 @@ void MKCpu::LogicOpAcc(unsigned short addr, int logop)
 void MKCpu::CompareOpAcc(unsigned char val)
 {
 	if (mReg.Flags & FLAGS_QUANTUM) {
-		qReg->SetBit(FLAGS_CARRY_Q, false);
 		qReg->DECSC(val, REGS_ACC_Q, REG_LEN, FLAGS_OVERFLOW_Q, FLAGS_CARRY_Q);
 		qReg->SetZeroFlag(REGS_ACC_Q, REG_LEN, FLAGS_ZERO_Q);
 		qReg->SetSignFlag(REGS_ACC_Q + REG_LEN - 1, FLAGS_SIGN_Q);
@@ -4851,11 +4850,11 @@ Regs *MKCpu::ExecOpcode(unsigned short memaddr)
 		Add2History(histentry);
 	}
 
-	for (int i = 0; i < 8; i++) {
-		std::cout << "Bit " << i <<" , chance of 1: " << qReg->Prob(i) << std::endl;
-	}
+	//for (int i = 0; i < 8; i++) {
+	//	std::cout << "Bit " << i <<" , chance of 1: " << qReg->Prob(i) << std::endl;
+	//}
 
-	std::cout << "Bit " << FLAGS_ZERO_Q <<" , chance of 1: " << qReg->Prob(FLAGS_ZERO_Q) << std::endl;
+	//std::cout << "Bit " << FLAGS_ZERO_Q <<" , chance of 1: " << qReg->Prob(FLAGS_ZERO_Q) << std::endl;
 	
 	return &mReg;
 }

--- a/MKCpu.h
+++ b/MKCpu.h
@@ -163,7 +163,7 @@ enum eOpCodes {
 	OPCODE_ILL_0C		= 0x0C,	// illegal opcode
 	OPCODE_ORA_ABS	= 0x0D,	// bitwise OR with Accumulator, Absolute ($0D addrlo addrhi : ORA addr ;addr=0..$FFFF), MEM=addr
 	OPCODE_ASL_ABS	= 0x0E,	// Arithmetic Shift Left, Absolute ($0E addrlo addrhi : ASL addr ;addr=0..$FFFF), MEM=addr
-	OPCODE_ILL_0F		= 0x0F,	// illegal opcode
+	OPCODE_SEN		= 0x0F,	// 6502Q: SEt Negative
 	OPCODE_BPL_REL	= 0x10,	// Branch on PLus, Relative ($10 signoffs : BPL signoffs ;signoffs=0..$FF [-128 ($80)..127 ($7F)])
 	OPCODE_ORA_IZY	= 0x11,	// bitwise OR with Accumulator, Indirect Indexed ($11 arg : ORA (arg),Y ;arg=0..$FF), MEM=&arg+Y
 	OPCODE_PAX_A		= 0x12,	// 6502Q: Pauli X on Accumulator
@@ -187,15 +187,15 @@ enum eOpCodes {
 	OPCODE_BIT_ZP		= 0x24,	// test BITs, Zero Page ($24 arg : BIT arg ;arg=0..$FF), MEM=arg
 	OPCODE_AND_ZP		=	0x25,	// bitwise AND with accumulator, Zero Page ($25 arg : AND arg ;arg=0..$FF), MEM=arg
 	OPCODE_ROL_ZP		= 0x26,	// ROtate Left, Zero Page ($26 arg : ROL arg ;arg=0..$FF), MEM=arg
-	OPCODE_ILL_27		= 0x27,	// illegal opcode
+	OPCODE_SEV		= 0x27,	// 6502Q: SEt oVerflow
 	OPCODE_PLP			= 0x28,	// PuLl Processor status, Implied ($28 : PLP)
 	OPCODE_AND_IMM	= 0x29,	// bitwise AND with accumulator, Immediate ($29 arg : AND #arg ;arg=0..$FF), MEM=PC+1
 	OPCODE_ROL			= 0x2A,	// ROtate Left, Accumulator ($2A : ROL)
-	OPCODE_ILL_2B		= 0x2B,	// illegal opcode
+	OPCODE_SEZ		= 0x2B,	// 6502Q: SEt Zero
 	OPCODE_BIT_ABS	= 0x2C,	// test BITs, Absolute ($2C addrlo addrhi : BIT addr ;addr=0..$FFFF), MEM=addr
 	OPCODE_AND_ABS	= 0x2D,	// bitwise AND with accumulator, Absolute ($2D addrlo addrhi : AND addr ;addr=0..$FFFF), MEM=addr
 	OPCODE_ROL_ABS	= 0x2E,	// ROtate Left, Absolute ($2E addrlo addrhi : ROL addr ;addr=0..$FFFF), MEM=addr
-	OPCODE_ILL_2F		= 0x2F,	// illegal opcode
+	OPCODE_CLN		= 0x2F,	// 6502Q: SEt Negative
 	OPCODE_BMI_REL	= 0x30,	// Branch on MInus, Relative ($30 signoffs : BMI signoffs ;signoffs=0..$FF [-128 ($80)..127 ($7F)])
 	OPCODE_AND_IZY	= 0x31,	// bitwise AND with accumulator, Indirect Indexed ($31 arg : AND (arg),Y ;arg=0..$FF), MEM=&arg+Y
 	OPCODE_PAZ_A		= 0x32,	// 6502Q: Pauli Z on Accumulator
@@ -219,7 +219,7 @@ enum eOpCodes {
 	OPCODE_ILL_44		= 0x44,	// illegal opcode
 	OPCODE_EOR_ZP		= 0x45,	// bitwise Exclusive OR, Zero Page ($45 arg : EOR arg ;arg=0..$FF), MEM=arg
 	OPCODE_LSR_ZP		= 0x46,	// Logical Shift Right, Zero Page ($46 arg : LSR arg ;arg=0..$FF), MEM=arg
-	OPCODE_ILL_47		= 0x47,	// illegal opcode
+	OPCODE_CLZ		= 0x47,	// 6502Q: CLear Zero
 	OPCODE_PHA			= 0x48,	// PusH Accumulator, Implied ($48 : PHA)
 	OPCODE_EOR_IMM	= 0x49,	// bitwise Exclusive OR, Immediate ($49 arg : EOR #arg ;arg=0..$FF), MEM=PC+1
 	OPCODE_LSR			= 0x4A,	// Logical Shift Right, Accumulator ($4A : LSR)
@@ -395,11 +395,11 @@ enum eOpCodes {
 	OPCODE_ILL_F4		= 0xF4,	// illegal opcode
 	OPCODE_SBC_ZPX	= 0xF5,	// SuBtract with Carry, Zero Page Indexed, X ($F5 arg : SBC arg,X ;arg=0..$FF), MEM=arg+X
 	OPCODE_INC_ZPX	= 0xF6,	// INCrement memory, Zero Page Indexed, X ($F6 arg : INC arg,X ;arg=0..$FF), MEM=arg+X
-	OPCODE_QXN_Z		= 0xF7,	// 6502Q: CNot the oracle qubit with control: zero flag
+	OPCODE_QZN_Z		= 0xF7,	// 6502Q: CNot the oracle qubit with control: zero flag
 	OPCODE_SED			= 0xF8,	// SEt Decimal, Implied ($F8 : SED)
 	OPCODE_SBC_ABY	= 0xF9,	// SuBtract with Carry, Absolute Indexed, Y ($F9 addrlo addrhi : SBC addr,Y ;addr=0..$FFFF), MEM=addr+Y
-	OPCODE_QXN_S		= 0xFA,	// 6502Q: CNot the oracle qubit with control: sign flag
-	OPCODE_QXN_C		= 0xFB,	// 6502Q: CNot the oracle qubit with control: carry flag
+	OPCODE_QZN_S		= 0xFA,	// 6502Q: CNot the oracle qubit with control: sign flag
+	OPCODE_QZN_C		= 0xFB,	// 6502Q: CNot the oracle qubit with control: carry flag
 	OPCODE_ILL_FC		= 0xFC,	// illegal opcode
 	OPCODE_SBC_ABX	= 0xFD,	// SuBtract with Carry, Absolute Indexed, X ($FD addrlo addrhi : SBC addr,X ;addr=0..$FFFF), MEM=addr+X
 	OPCODE_INC_ABX	= 0xFE,	// INCrement memory, Absolute Indexed, X ($FE addrlo addrhi : INC addr,X ;addr=0..$FFFF), MEM=addr+X
@@ -737,10 +737,15 @@ class MKCpu
 		void OpCodeHav();
 		void OpCodeClq();
 		void OpCodeSeq();
-		void OpCodeQxZero();
-		void OpCodeQxSign();
-		void OpCodeQxCarry();
-		void OpCodeQxOver();
+		void OpCodeQzZero();
+		void OpCodeQzSign();
+		void OpCodeQzCarry();
+		void OpCodeQzOver();
+		void OpCodeSen();
+		void OpCodeCln();
+		void OpCodeSev();
+		void OpCodeSez();
+		void OpCodeClz();
 };
 
 } // namespace MKBasic

--- a/MKCpu.h
+++ b/MKCpu.h
@@ -78,13 +78,11 @@ struct Regs {
 
 #define REGS_ACC_Q		0
 #define REGS_INDX_Q		8
-#define REGS_CMPW_Q		20
 #define REG_LEN			8
 #define FLAGS_CARRY_Q		16
 #define FLAGS_ZERO_Q		17
 #define FLAGS_OVERFLOW_Q	18
 #define FLAGS_SIGN_Q		19
-#define FLAGS_ORACLE_Q		20
 
 /*
  * Virtual CPU, 6502 addressing modes:
@@ -181,7 +179,7 @@ enum eOpCodes {
 	OPCODE_ILL_1C		= 0x1C,	// illegal opcode
 	OPCODE_ORA_ABX	= 0x1D,	// bitwise OR with Accumulator, Absolute Indexed, X ($1D addrlo addrhi : ORA addr,X ;addr=0..$FFFF), MEM=addr+X
 	OPCODE_ASL_ABX	= 0x1E,	// Arithmetic Shift Left, Absolute Indexed, X ($1E addrlo addrhi : ASL addr,X ;addr=0..$FFFF), MEM=addr+X
-	OPCODE_CLO			= 0x1F,	// 6502Q: Clear Oracle Qubit
+	OPCODE_CLQ			= 0x1F,	// 6502Q: Clear Quantum Mode Flag
 	OPCODE_JSR_ABS	= 0x20,	// Jump to SubRoutine, Absolute ($20 addrlo addrhi : JSR addr ;addr=0..$FFFF), MEM=addr
 	OPCODE_AND_IZX	=	0x21,	// bitwise AND with accumulator, Indexed Indirect ($21 arg : AND (arg,X) ;arg=0..$FF), MEM=&(arg+X)
 	OPCODE_ILL_22		= 0x22,	// illegal opcode
@@ -213,7 +211,7 @@ enum eOpCodes {
 	OPCODE_ILL_3C		= 0x3C,	// illegal opcode	
 	OPCODE_AND_ABX	=	0x3D,	// bitwise AND with accumulator, Absolute Indexed, X ($3D addrlo addrhi : AND addr,X ;addr=0..$FFFF), MEM=addr+X
 	OPCODE_ROL_ABX	= 0x3E,	// ROtate Left, Absolute Indexed, X ($3E addrlo addrhi : ROL addr,X ;addr=0..$FFFF), MEM=addr+X
-	OPCODE_SEO		= 0x3F,	// 6502Q: Set Oracle Flag
+	OPCODE_SEQ		= 0x3F,	// 6502Q: Set Quantum Mode Flag
 	OPCODE_RTI			= 0x40,	// ReTurn from Interrupt, Implied ($40 : RTI)
 	OPCODE_EOR_IZX	= 0x41,	// bitwise Exclusive OR, Indexed Indirect ($41 arg : EOR (arg,X) ;arg=0..$FF), MEM=&(arg+X)
 	OPCODE_ROTX_A		= 0x42,	// 6502Q: Quarter rotation on X axis for Accumulator
@@ -397,12 +395,12 @@ enum eOpCodes {
 	OPCODE_ILL_F4		= 0xF4,	// illegal opcode
 	OPCODE_SBC_ZPX	= 0xF5,	// SuBtract with Carry, Zero Page Indexed, X ($F5 arg : SBC arg,X ;arg=0..$FF), MEM=arg+X
 	OPCODE_INC_ZPX	= 0xF6,	// INCrement memory, Zero Page Indexed, X ($F6 arg : INC arg,X ;arg=0..$FF), MEM=arg+X
-	OPCODE_OCN_Z		= 0xF7,	// 6502Q: CNot the oracle qubit with control: zero flag
+	OPCODE_QXN_Z		= 0xF7,	// 6502Q: CNot the oracle qubit with control: zero flag
 	OPCODE_SED			= 0xF8,	// SEt Decimal, Implied ($F8 : SED)
 	OPCODE_SBC_ABY	= 0xF9,	// SuBtract with Carry, Absolute Indexed, Y ($F9 addrlo addrhi : SBC addr,Y ;addr=0..$FFFF), MEM=addr+Y
-	OPCODE_OCN_S		= 0xFA,	// 6502Q: CNot the oracle qubit with control: sign flag
-	OPCODE_OCN_C		= 0xFB,	// 6502Q: CNot the oracle qubit with control: carry flag
-	OPCODE_OCN_O		= 0xFC,	// 6502Q: CNot the oracle qubit with control: overflow flag
+	OPCODE_QXN_S		= 0xFA,	// 6502Q: CNot the oracle qubit with control: sign flag
+	OPCODE_QXN_C		= 0xFB,	// 6502Q: CNot the oracle qubit with control: carry flag
+	OPCODE_ILL_FC		= 0xFC,	// illegal opcode
 	OPCODE_SBC_ABX	= 0xFD,	// SuBtract with Carry, Absolute Indexed, X ($FD addrlo addrhi : SBC addr,X ;addr=0..$FFFF), MEM=addr+X
 	OPCODE_INC_ABX	= 0xFE,	// INCrement memory, Absolute Indexed, X ($FE addrlo addrhi : INC addr,X ;addr=0..$FFFF), MEM=addr+X
 	OPCODE_ILL_FF		= 0xFF	// illegal opcode
@@ -456,7 +454,7 @@ enum eCpuFlagMasks {
 	FLAGS_IRQ				= 0x04,		// 2: I
 	FLAGS_DEC				= 0x08,		// 3: D
 	FLAGS_BRK				= 0x10,		// 4: B (Clear if interrupt vectoring, set if BRK or PHP)
-	FLAGS_ORACLE		= 0x20,		// 5: 6502Q: Oracle Qubit Flag
+	FLAGS_QUANTUM		= 0x20,		// 5: 6502Q: Quantum mode flag
 	FLAGS_OVERFLOW 	= 0x40,		// 6: V
 	FLAGS_SIGN 			= 0x80		// 7: N
 };
@@ -733,15 +731,16 @@ class MKCpu
 		//void OpCodeCXA();
 		//void OpCodeCAX();
 		void OpCodeLdaAba();
-		void OpCodeHao();
+		void OpCodeHaz();
+		void OpCodeHas();
 		void OpCodeHac();
 		void OpCodeHav();
-		void OpCodeClo();
-		void OpCodeSeo();
-		void OpCodeOcnZero();
-		void OpCodeOcnSign();
-		void OpCodeOcnCarry();
-		void OpCodeOcnOver();
+		void OpCodeClq();
+		void OpCodeSeq();
+		void OpCodeQxZero();
+		void OpCodeQxSign();
+		void OpCodeQxCarry();
+		void OpCodeQxOver();
 };
 
 } // namespace MKBasic

--- a/MKCpu.h
+++ b/MKCpu.h
@@ -395,11 +395,11 @@ enum eOpCodes {
 	OPCODE_ILL_F4		= 0xF4,	// illegal opcode
 	OPCODE_SBC_ZPX	= 0xF5,	// SuBtract with Carry, Zero Page Indexed, X ($F5 arg : SBC arg,X ;arg=0..$FF), MEM=arg+X
 	OPCODE_INC_ZPX	= 0xF6,	// INCrement memory, Zero Page Indexed, X ($F6 arg : INC arg,X ;arg=0..$FF), MEM=arg+X
-	OPCODE_QZN_Z		= 0xF7,	// 6502Q: CNot the oracle qubit with control: zero flag
+	OPCODE_QZN_Z		= 0xF7,	// 6502Q: Apply Z operator to zero flag
 	OPCODE_SED			= 0xF8,	// SEt Decimal, Implied ($F8 : SED)
 	OPCODE_SBC_ABY	= 0xF9,	// SuBtract with Carry, Absolute Indexed, Y ($F9 addrlo addrhi : SBC addr,Y ;addr=0..$FFFF), MEM=addr+Y
-	OPCODE_QZN_S		= 0xFA,	// 6502Q: CNot the oracle qubit with control: sign flag
-	OPCODE_QZN_C		= 0xFB,	// 6502Q: CNot the oracle qubit with control: carry flag
+	OPCODE_QZN_S		= 0xFA,	// 6502Q: Apply Z operator to negative flag
+	OPCODE_QZN_C		= 0xFB,	// 6502Q: Apply Z operator to carry flag
 	OPCODE_ILL_FC		= 0xFC,	// illegal opcode
 	OPCODE_SBC_ABX	= 0xFD,	// SuBtract with Carry, Absolute Indexed, X ($FD addrlo addrhi : SBC addr,X ;addr=0..$FFFF), MEM=addr+X
 	OPCODE_INC_ABX	= 0xFE,	// INCrement memory, Absolute Indexed, X ($FE addrlo addrhi : INC addr,X ;addr=0..$FFFF), MEM=addr+X

--- a/dummy.ram
+++ b/dummy.ram
@@ -392,30 +392,26 @@ $0b00
 ; perform Grover's search on $0f00 to $0fff
 ; store result in $0bff
 ;
-; GINIT:	seo
-;		hao
-; 		ldx #$00
-; 		hax
-; 		lda $0f00,X
+; GINIT:	clq
 ;		ldy #$08
-;		sbc #$64
-; GITER:	ocz
+; 		lda #00
 ;		haa
-;		pxa
-;		r1a
-;		r1a
-;		pxa
+; GITER:	seq
+;		cmp #64
 ;		haa
+;		qxz
+;		haa
+;		cmp #00
+;		clq
 ;		dey
 ;		bne GITER
-;		adc #64
 ;		cmp #64
 ;		bne GINIT
-;		stx $0bff
+;		sta $0bff
 ;		brk
 ;
-$3f $07 $a2 $00 $03 $bd $00 $0f $a0 $08 $e9 $64 $f7 $02 $12 $3a
-$3a $12 $02 $88 $d0 $f6 $69 $64 $c9 $64 $d0 $e4 $8e $ff $0b $00
+$1f $a0 $0c $a9 $00 $02 $3f $c9 $64 $02 $f7 $02 $c9 $00 $1f $88
+$d0 $f3 $c9 $64 $d0 $ea $81 $ff $0b $00 
 ORG
 $0f00
 $ff $fe $fd $fc $fb $fa $f9 $f8 $f7 $f6 $f5 $f4 $f3 $f2 $f1 $f0

--- a/dummy.ram
+++ b/dummy.ram
@@ -396,15 +396,14 @@ $0b00
 ;		ldy #$08
 ; 		lda #00
 ;		adc #00 	;clear flags
-;		hav		;disengage overflow
-;		has		;disengage sign
 ;		haa
 ; GITER:	seq
+;		sez
 ;		cmp #64
 ;		haa
-;		qxz
+;		qzz
+;		clz
 ;		haa
-;		adc #00
 ;		clq
 ;		dey
 ;		bne GITER
@@ -413,8 +412,8 @@ $0b00
 ;		sta $0bff
 ;		brk
 ;
-$1f $a0 $0c $a9 $00 $69 $00 $07 $b7 $02 $3f $c9 $64 $02 $f7 $02
-$69 $00 $1f $88 $d0 $f4 $c9 $64 $d0 $e6 $81 $ff $0b $00 
+$1f $a0 $0c $a9 $00 $69 $00 $02 $3f $2b $c9 $64 $02 $f7 $47 $02
+$1f $88 $d0 $f4 $c9 $64 $d0 $e8 $81 $ff $0b $00 
 ORG
 $0f00
 $ff $fe $fd $fc $fb $fa $f9 $f8 $f7 $f6 $f5 $f4 $f3 $f2 $f1 $f0

--- a/dummy.ram
+++ b/dummy.ram
@@ -404,7 +404,7 @@ $0b00
 ;		haa
 ;		qxz
 ;		haa
-;		cmp #00
+;		adc #00
 ;		clq
 ;		dey
 ;		bne GITER
@@ -414,7 +414,7 @@ $0b00
 ;		brk
 ;
 $1f $a0 $0c $a9 $00 $69 $00 $07 $b7 $02 $3f $c9 $64 $02 $f7 $02
-$c9 $00 $1f $88 $d0 $f4 $c9 $64 $d0 $e6 $81 $ff $0b $00 
+$69 $00 $1f $88 $d0 $f4 $c9 $64 $d0 $e6 $81 $ff $0b $00 
 ORG
 $0f00
 $ff $fe $fd $fc $fb $fa $f9 $f8 $f7 $f6 $f5 $f4 $f3 $f2 $f1 $f0

--- a/dummy.ram
+++ b/dummy.ram
@@ -395,6 +395,9 @@ $0b00
 ; GINIT:	clq
 ;		ldy #$08
 ; 		lda #00
+;		adc #00 	;clear flags
+;		hav		;disengage overflow
+;		has		;disengage sign
 ;		haa
 ; GITER:	seq
 ;		cmp #64
@@ -410,8 +413,8 @@ $0b00
 ;		sta $0bff
 ;		brk
 ;
-$1f $a0 $0c $a9 $00 $02 $3f $c9 $64 $02 $f7 $02 $c9 $00 $1f $88
-$d0 $f3 $c9 $64 $d0 $ea $81 $ff $0b $00 
+$1f $a0 $0c $a9 $00 $69 $00 $07 $b7 $02 $3f $c9 $64 $02 $f7 $02
+$c9 $00 $1f $88 $d0 $f4 $c9 $64 $d0 $e6 $81 $ff $0b $00 
 ORG
 $0f00
 $ff $fe $fd $fc $fb $fa $f9 $f8 $f7 $f6 $f5 $f4 $f3 $f2 $f1 $f0

--- a/main.cpp
+++ b/main.cpp
@@ -377,7 +377,7 @@ bool ShowRegs(Regs *preg, VMachine *pvm, bool ioecho, bool showiostat)
 	cout << sBuf << endl;
 	cout << "*-------------*-----------------------*----------*----------*";
 	cout << endl;
-	cout << "|  NV-BDIZC   |";
+	cout << "|  NVQBDIZC   |";
 	cout << " : " << diss_buf << "          " << endl;
 	cout << "|  " << bitset<8>((int)preg->Flags) << "   |";
 	cout << " : " << curr_buf << "          " << endl;


### PR DESCRIPTION
(Also see the corresponding pull request on the qrack project)

Earlier attempts to implement Grover's relied on applying the X or NOT operator to flag bits on vm6502q. While literature on Grover's algorithm suggests this is a workable approach, Grover's is usually instead implemented in terms of phase shifts, with the Z operator. The Z operator rotates the phase of a |1> bit by pi and leaves a |0> bit unchanged.

This is a very powerful standardization of the behavior for quantum flag bits! Now, a quantum mode flag changes vm6502q from classical operation to Z-flip mode, or "quantum mode." When the quantum mode flag is engaged, operations that would set a flag bit instead apply a Z operator to it. If the flag is set to |0>, there is no effect. If the flag is set to |1>, its phase is flipped, allowing for amplitude amplification on the basis of the 6502's status flags. Set and clear operations have been implemented as necessary for the sign, zero, carry, and overflow flags, to use this mode.

The CMP operation is the primary "workhorse" of amplitude amplification in quantum mode. Temporarily, the effect of CMP on the carry flag has been disabled, as the carry flag functions differently from the other flags in a way that makes it harder to handle. We should discuss how to reincorporate the carry flag in CMP and in general.