### PR TITLE
New opcode and lookup table inversion example

### DIFF
--- a/MKCpu.cpp
+++ b/MKCpu.cpp
@@ -145,8 +145,8 @@ void MKCpu::InitCpu()
 		{OPCODE_PHP,		{OPCODE_PHP,		ADDRMODE_IMP,		3,		"PHP",	&MKCpu::OpCodePhp		/*08*/	}},
 		{OPCODE_ORA_IMM,	{OPCODE_ORA_IMM,	ADDRMODE_IMM,		2,		"ORA",	&MKCpu::OpCodeOraImm 		/*09*/	}},
 		{OPCODE_ASL,		{OPCODE_ASL,		ADDRMODE_ACC,		2,		"ASL",	&MKCpu::OpCodeAslAcc		/*0a*/	}},
-		{OPCODE_ILL_0B,		{OPCODE_ILL_0B,		ADDRMODE_IMP,		2,		"NOP",	&MKCpu::OpCodeDud 		/*0b*/	}},
-		{OPCODE_ILL_0C,		{OPCODE_ILL_0C,		ADDRMODE_IMP,		2,		"NOP",	&MKCpu::OpCodeDud		/*0c*/	}},
+		{OPCODE_EHX,		{OPCODE_EHX,		ADDRMODE_IMP,		2,		"EHX",	&MKCpu::OpCodeEhx 		/*0b*/	}},
+		{OPCODE_ILL_0C,		{OPCODE_ILL_0C,		ADDRMODE_IMP,		2,		"EHY",	&MKCpu::OpCodeDud		/*0c*/	}},
 		{OPCODE_ORA_ABS,	{OPCODE_ORA_ABS,	ADDRMODE_ABS,		4,		"ORA",	&MKCpu::OpCodeOraAbs 		/*0d*/	}},
 		{OPCODE_ASL_ABS,	{OPCODE_ASL_ABS,	ADDRMODE_ABS,		6,		"ASL",	&MKCpu::OpCodeAslAbs 		/*0e*/	}},
 		{OPCODE_SEN,		{OPCODE_SEN,		ADDRMODE_IMP,		6,		"SEN",	&MKCpu::OpCodeSen 		/*0f*/	}},
@@ -3110,7 +3110,7 @@ void MKCpu::OpCodePla()
 
 /*
  *--------------------------------------------------------------------
- * Method:		OpCodeClo()
+ * Method:		OpCodeClq()
  * Purpose:		Clear quantum mode flag, IMPlied addressing mode.
  * Arguments:		n/a
  * Returns:		n/a
@@ -4841,6 +4841,23 @@ void MKCpu::OpCodeClz()
 {
 	mReg.Flags &= (~FLAGS_ZERO);
 	qReg->SetBit(FLAGS_ZERO_Q, false);
+}
+
+/*
+ *--------------------------------------------------------------------
+ * Method:		OpCodeEhx()
+ * Purpose:		"Entangled Hadamard" on X
+ * Arguments:		n/a
+ * Returns:		n/a
+ *--------------------------------------------------------------------
+ */
+void MKCpu::OpCodeEhx()
+{
+        qReg->EntangledH(REGS_INDX_Q, REGS_ACC_Q, REG_LEN);
+	mReg.IndX = RotateClassical(mReg.IndX);
+        mReg.Acc = RotateClassical(mReg.Acc);
+        SetFlagsRegQ(REGS_INDX_Q);
+        SetFlags(mReg.IndX);
 }
 
 /*

--- a/MKCpu.cpp
+++ b/MKCpu.cpp
@@ -146,7 +146,7 @@ void MKCpu::InitCpu()
 		{OPCODE_ORA_IMM,	{OPCODE_ORA_IMM,	ADDRMODE_IMM,		2,		"ORA",	&MKCpu::OpCodeOraImm 		/*09*/	}},
 		{OPCODE_ASL,		{OPCODE_ASL,		ADDRMODE_ACC,		2,		"ASL",	&MKCpu::OpCodeAslAcc		/*0a*/	}},
 		{OPCODE_EHX,		{OPCODE_EHX,		ADDRMODE_IMP,		2,		"EHX",	&MKCpu::OpCodeEhx 		/*0b*/	}},
-		{OPCODE_ILL_0C,		{OPCODE_ILL_0C,		ADDRMODE_IMP,		2,		"EHY",	&MKCpu::OpCodeDud		/*0c*/	}},
+		{OPCODE_EHY,		{OPCODE_EHY,		ADDRMODE_IMP,		2,		"EHY",	&MKCpu::OpCodeDud		/*0c*/	}},
 		{OPCODE_ORA_ABS,	{OPCODE_ORA_ABS,	ADDRMODE_ABS,		4,		"ORA",	&MKCpu::OpCodeOraAbs 		/*0d*/	}},
 		{OPCODE_ASL_ABS,	{OPCODE_ASL_ABS,	ADDRMODE_ABS,		6,		"ASL",	&MKCpu::OpCodeAslAbs 		/*0e*/	}},
 		{OPCODE_SEN,		{OPCODE_SEN,		ADDRMODE_IMP,		6,		"SEN",	&MKCpu::OpCodeSen 		/*0f*/	}},
@@ -4853,11 +4853,11 @@ void MKCpu::OpCodeClz()
  */
 void MKCpu::OpCodeEhx()
 {
-        qReg->EntangledH(REGS_INDX_Q, REGS_ACC_Q, REG_LEN);
+	qReg->EntangledH(REGS_INDX_Q, REGS_ACC_Q, REG_LEN);
 	mReg.IndX = RotateClassical(mReg.IndX);
-        mReg.Acc = RotateClassical(mReg.Acc);
-        SetFlagsRegQ(REGS_INDX_Q);
-        SetFlags(mReg.IndX);
+	mReg.Acc = RotateClassical(mReg.Acc);
+	SetFlagsRegQ(REGS_INDX_Q);
+	SetFlags(mReg.IndX);
 }
 
 /*

--- a/MKCpu.h
+++ b/MKCpu.h
@@ -159,7 +159,7 @@ enum eOpCodes {
 	OPCODE_PHP			= 0x08,	// PusH Processor status on Stack, Implied ($08 : PHP)
 	OPCODE_ORA_IMM	= 0x09,	// bitwise OR with Accumulator, Immediate ($09 arg : ORA #arg ;arg=0..$FF), MEM=PC+1
 	OPCODE_ASL			= 0x0A,	// Arithmetic Shift Left, Accumulator ($0A : ASL)
-	OPCODE_ILL_0B		= 0x0B,	// illegal opcode
+	OPCODE_EHX		= 0x0B,	// 6502Q: "Entangled Hadamard" on X register, Hadamard-like operation on X while entangled with the accumulator.
 	OPCODE_ILL_0C		= 0x0C,	// illegal opcode
 	OPCODE_ORA_ABS	= 0x0D,	// bitwise OR with Accumulator, Absolute ($0D addrlo addrhi : ORA addr ;addr=0..$FFFF), MEM=addr
 	OPCODE_ASL_ABS	= 0x0E,	// Arithmetic Shift Left, Absolute ($0E addrlo addrhi : ASL addr ;addr=0..$FFFF), MEM=addr
@@ -746,6 +746,7 @@ class MKCpu
 		void OpCodeSev();
 		void OpCodeSez();
 		void OpCodeClz();
+		void OpCodeEhx();
 };
 
 } // namespace MKBasic

--- a/MKCpu.h
+++ b/MKCpu.h
@@ -159,11 +159,11 @@ enum eOpCodes {
 	OPCODE_PHP			= 0x08,	// PusH Processor status on Stack, Implied ($08 : PHP)
 	OPCODE_ORA_IMM	= 0x09,	// bitwise OR with Accumulator, Immediate ($09 arg : ORA #arg ;arg=0..$FF), MEM=PC+1
 	OPCODE_ASL			= 0x0A,	// Arithmetic Shift Left, Accumulator ($0A : ASL)
-	OPCODE_EHX		= 0x0B,	// 6502Q: "Entangled Hadamard" on X register, Hadamard-like operation on X while entangled with the accumulator.
-	OPCODE_ILL_0C		= 0x0C,	// illegal opcode
+	OPCODE_EHX			= 0x0B,	// 6502Q: "Entangled Hadamard" on X register, Hadamard-like operation on X while entangled with the accumulator.
+	OPCODE_EHY			= 0x0C,	// 6502Q: "Entangled Hadamard" on Y register, Hadamard-like operation on Y while entangled with the accumulator.
 	OPCODE_ORA_ABS	= 0x0D,	// bitwise OR with Accumulator, Absolute ($0D addrlo addrhi : ORA addr ;addr=0..$FFFF), MEM=addr
 	OPCODE_ASL_ABS	= 0x0E,	// Arithmetic Shift Left, Absolute ($0E addrlo addrhi : ASL addr ;addr=0..$FFFF), MEM=addr
-	OPCODE_SEN		= 0x0F,	// 6502Q: SEt Negative
+	OPCODE_SEN			= 0x0F,	// 6502Q: SEt Negative
 	OPCODE_BPL_REL	= 0x10,	// Branch on PLus, Relative ($10 signoffs : BPL signoffs ;signoffs=0..$FF [-128 ($80)..127 ($7F)])
 	OPCODE_ORA_IZY	= 0x11,	// bitwise OR with Accumulator, Indirect Indexed ($11 arg : ORA (arg),Y ;arg=0..$FF), MEM=&arg+Y
 	OPCODE_PAX_A		= 0x12,	// 6502Q: Pauli X on Accumulator
@@ -187,15 +187,15 @@ enum eOpCodes {
 	OPCODE_BIT_ZP		= 0x24,	// test BITs, Zero Page ($24 arg : BIT arg ;arg=0..$FF), MEM=arg
 	OPCODE_AND_ZP		=	0x25,	// bitwise AND with accumulator, Zero Page ($25 arg : AND arg ;arg=0..$FF), MEM=arg
 	OPCODE_ROL_ZP		= 0x26,	// ROtate Left, Zero Page ($26 arg : ROL arg ;arg=0..$FF), MEM=arg
-	OPCODE_SEV		= 0x27,	// 6502Q: SEt oVerflow
+	OPCODE_SEV			= 0x27,	// 6502Q: SEt oVerflow
 	OPCODE_PLP			= 0x28,	// PuLl Processor status, Implied ($28 : PLP)
 	OPCODE_AND_IMM	= 0x29,	// bitwise AND with accumulator, Immediate ($29 arg : AND #arg ;arg=0..$FF), MEM=PC+1
 	OPCODE_ROL			= 0x2A,	// ROtate Left, Accumulator ($2A : ROL)
-	OPCODE_SEZ		= 0x2B,	// 6502Q: SEt Zero
+	OPCODE_SEZ			= 0x2B,	// 6502Q: SEt Zero
 	OPCODE_BIT_ABS	= 0x2C,	// test BITs, Absolute ($2C addrlo addrhi : BIT addr ;addr=0..$FFFF), MEM=addr
 	OPCODE_AND_ABS	= 0x2D,	// bitwise AND with accumulator, Absolute ($2D addrlo addrhi : AND addr ;addr=0..$FFFF), MEM=addr
 	OPCODE_ROL_ABS	= 0x2E,	// ROtate Left, Absolute ($2E addrlo addrhi : ROL addr ;addr=0..$FFFF), MEM=addr
-	OPCODE_CLN		= 0x2F,	// 6502Q: SEt Negative
+	OPCODE_CLN			= 0x2F,	// 6502Q: SEt Negative
 	OPCODE_BMI_REL	= 0x30,	// Branch on MInus, Relative ($30 signoffs : BMI signoffs ;signoffs=0..$FF [-128 ($80)..127 ($7F)])
 	OPCODE_AND_IZY	= 0x31,	// bitwise AND with accumulator, Indirect Indexed ($31 arg : AND (arg),Y ;arg=0..$FF), MEM=&arg+Y
 	OPCODE_PAZ_A		= 0x32,	// 6502Q: Pauli Z on Accumulator
@@ -211,7 +211,7 @@ enum eOpCodes {
 	OPCODE_ILL_3C		= 0x3C,	// illegal opcode	
 	OPCODE_AND_ABX	=	0x3D,	// bitwise AND with accumulator, Absolute Indexed, X ($3D addrlo addrhi : AND addr,X ;addr=0..$FFFF), MEM=addr+X
 	OPCODE_ROL_ABX	= 0x3E,	// ROtate Left, Absolute Indexed, X ($3E addrlo addrhi : ROL addr,X ;addr=0..$FFFF), MEM=addr+X
-	OPCODE_SEQ		= 0x3F,	// 6502Q: Set Quantum Mode Flag
+	OPCODE_SEQ			= 0x3F,	// 6502Q: Set Quantum Mode Flag
 	OPCODE_RTI			= 0x40,	// ReTurn from Interrupt, Implied ($40 : RTI)
 	OPCODE_EOR_IZX	= 0x41,	// bitwise Exclusive OR, Indexed Indirect ($41 arg : EOR (arg,X) ;arg=0..$FF), MEM=&(arg+X)
 	OPCODE_ROTX_A		= 0x42,	// 6502Q: Quarter rotation on X axis for Accumulator
@@ -219,7 +219,7 @@ enum eOpCodes {
 	OPCODE_ILL_44		= 0x44,	// illegal opcode
 	OPCODE_EOR_ZP		= 0x45,	// bitwise Exclusive OR, Zero Page ($45 arg : EOR arg ;arg=0..$FF), MEM=arg
 	OPCODE_LSR_ZP		= 0x46,	// Logical Shift Right, Zero Page ($46 arg : LSR arg ;arg=0..$FF), MEM=arg
-	OPCODE_CLZ		= 0x47,	// 6502Q: CLear Zero
+	OPCODE_CLZ			= 0x47,	// 6502Q: CLear Zero
 	OPCODE_PHA			= 0x48,	// PusH Accumulator, Implied ($48 : PHA)
 	OPCODE_EOR_IMM	= 0x49,	// bitwise Exclusive OR, Immediate ($49 arg : EOR #arg ;arg=0..$FF), MEM=PC+1
 	OPCODE_LSR			= 0x4A,	// Logical Shift Right, Accumulator ($4A : LSR)

--- a/dummy.ram
+++ b/dummy.ram
@@ -418,7 +418,7 @@ $f7 $1f $88 $d0 $f3 $c9 $64 $d0 $e7 $81 $ff $0b $00
 ORG
 $0c00
 ;
-; test program #11
+; test program #12
 ; address: $0c00
 ; Search lookup table in $0f00 to $0fff with amplitude amplification
 ; store result in $0bff

--- a/dummy.ram
+++ b/dummy.ram
@@ -389,32 +389,65 @@ $0b00
 ;
 ; test program #11
 ; address: $0b00
-; perform Grover's search on $0f00 to $0fff
+; perform Grover's search on "subroutine"
 ; store result in $0bff
 ;
 ; GINIT:	clq
-;		ldy #$08
-; 		lda #00
-;		adc #00 	;clear flags
+;		ldy #$0c
+; 		lda #$00
+;		adc #$00 	;clear flags
 ;		haa
 ; GITER:	seq
 ;		sez
 ;		clc
-;		cmp #64
+;		cmp #$64
 ;		haa
-;		qzz
 ;		clz
 ;		haa
+;               qzz
 ;		clq
 ;		dey
 ;		bne GITER
-;		cmp #64
+;		cmp #$64
 ;		bne GINIT
 ;		sta $0bff
 ;		brk
 ;
-$1f $a0 $0c $a9 $00 $69 $00 $02 $3f $2b $18 $c9 $64 $02 $f7 $47
-$02 $1f $88 $d0 $f3 $c9 $64 $d0 $e7 $81 $ff $0b $00 
+$1f $a0 $0c $a9 $00 $69 $00 $02 $3f $2b $18 $c9 $64 $02 $47 $02
+$f7 $1f $88 $d0 $f3 $c9 $64 $d0 $e7 $81 $ff $0b $00
+ORG
+$0c00
+;
+; test program #11
+; address: $0c00
+; Search lookup table in $0f00 to $0fff with amplitude amplification
+; store result in $0bff
+;
+; GINIT:	clq
+;		ldy #$0c
+; 		ldx #$00
+;               hax
+;               lda $0f00,X
+;               cln
+;               clv
+; GITER:	seq
+;		sez
+;		clc
+;		cmp #$64
+;		ehx
+;		qzz
+;		clz
+;		ehx
+;		clq
+;		dey
+;		bne GITER
+;		cmp #$64
+;		bne GINIT
+;		stx $0cff
+;		brk
+;
+$1f $a0 $0c $a2 $00 $03 $bd $00 $0f $2f $b8 $3f $2b $18 $c9 $64
+$0b $47 $0b $f7 $1f $88 $d0 $f3 $c9 $64 $d0 $e4 $8e $ff $0c $00 
 ORG
 $0f00
 $ff $fe $fd $fc $fb $fa $f9 $f8 $f7 $f6 $f5 $f4 $f3 $f2 $f1 $f0

--- a/makefile
+++ b/makefile
@@ -41,11 +41,11 @@ endif
 all: all-before $(BIN) bin2hex all-after
 
 $(QRACKLIBS):
-	ENABLE_OPENCL=$(ENABLE_OPENCL) make -C qrack
+	ENABLE_OPENCL=$(ENABLE_OPENCL) ${MAKE} -C qrack
 
 clean: clean-custom
 	${RM} $(OBJ) testall.o $(BIN) bin2hex
-	ENABLE_OPENCL=$(ENABLE_OPENCL) make -C qrack clean
+	ENABLE_OPENCL=$(ENABLE_OPENCL) ${MAKE} -C qrack clean
 
 $(BIN): $(OBJ) ${QRACKLIBS}
 	$(CPP) $(LINKOBJ) $(QRACKLIBS) -o $(BIN) $(LDFLAGS) $(LIBS) $(SDLLIBS)


### PR DESCRIPTION
(See: https://github.com/vm6502q/qrack/pull/17 )

The "entangled Hadamard" gate has been incorporated into vm6502q.