### PR TITLE
Removing EHX and fixing examples

### DIFF
--- a/MKCpu.cpp
+++ b/MKCpu.cpp
@@ -145,7 +145,7 @@ void MKCpu::InitCpu()
 		{OPCODE_PHP,		{OPCODE_PHP,		ADDRMODE_IMP,		3,		"PHP",	&MKCpu::OpCodePhp		/*08*/	}},
 		{OPCODE_ORA_IMM,	{OPCODE_ORA_IMM,	ADDRMODE_IMM,		2,		"ORA",	&MKCpu::OpCodeOraImm 		/*09*/	}},
 		{OPCODE_ASL,		{OPCODE_ASL,		ADDRMODE_ACC,		2,		"ASL",	&MKCpu::OpCodeAslAcc		/*0a*/	}},
-		{OPCODE_EHX,		{OPCODE_EHX,		ADDRMODE_IMP,		2,		"EHX",	&MKCpu::OpCodeEhx 		/*0b*/	}},
+		{OPCODE_ILL_0B,		{OPCODE_ILL_0B,		ADDRMODE_IMM,		2,		"ANC",	&MKCpu::OpCodeDud 		/*0b*/	}},
 		{OPCODE_ILL_0C,		{OPCODE_ILL_0C,		ADDRMODE_ABS,		4,		"NOP",	&MKCpu::OpCodeDud		/*0c*/	}},
 		{OPCODE_ORA_ABS,	{OPCODE_ORA_ABS,	ADDRMODE_ABS,		4,		"ORA",	&MKCpu::OpCodeOraAbs 		/*0d*/	}},
 		{OPCODE_ASL_ABS,	{OPCODE_ASL_ABS,	ADDRMODE_ABS,		6,		"ASL",	&MKCpu::OpCodeAslAbs 		/*0e*/	}},
@@ -5028,24 +5028,6 @@ void MKCpu::OpCodeClz()
 {
 	mReg.LastAddrMode = ADDRMODE_IMP;
 	mReg.Flags &= ~FLAGS_ZERO;
-}
-
-/*
- *--------------------------------------------------------------------
- * Method:		OpCodeEhx()
- * Purpose:		"Entangled Hadamard" on X
- * Arguments:		n/a
- * Returns:		n/a
- *--------------------------------------------------------------------
- */
-void MKCpu::OpCodeEhx()
-{
-	PrepareAccQ();
-	PrepareXQ();
-	qReg->EntangledH(REGS_INDX_Q, REGS_ACC_Q, REG_LEN);
-	mReg.IndX = RotateClassical(mReg.IndX);
-	mReg.Acc = RotateClassical(mReg.Acc);
-	SetFlagsReg(REGS_INDX_Q);
 }
 
 /*

--- a/MKCpu.h
+++ b/MKCpu.h
@@ -159,7 +159,7 @@ enum eOpCodes {
 	OPCODE_PHP			= 0x08,	// PusH Processor status on Stack, Implied ($08 : PHP)
 	OPCODE_ORA_IMM	= 0x09,	// bitwise OR with Accumulator, Immediate ($09 arg : ORA #arg ;arg=0..$FF), MEM=PC+1
 	OPCODE_ASL			= 0x0A,	// Arithmetic Shift Left, Accumulator ($0A : ASL)
-	OPCODE_EHX			= 0x0B,	// 6502Q: "Entangled Hadamard" on X register, Hadamard-like operation on X while entangled with the accumulator.
+	OPCODE_ILL_0B			= 0x0B,	// 6502Q: "Entangled Hadamard" on X register, Hadamard-like operation on X while entangled with the accumulator.
 	OPCODE_ILL_0C			= 0x0C,	// illegal opcode
 	OPCODE_ORA_ABS	= 0x0D,	// bitwise OR with Accumulator, Absolute ($0D addrlo addrhi : ORA addr ;addr=0..$FFFF), MEM=addr
 	OPCODE_ASL_ABS	= 0x0E,	// Arithmetic Shift Left, Absolute ($0E addrlo addrhi : ASL addr ;addr=0..$FFFF), MEM=addr
@@ -745,7 +745,6 @@ class MKCpu
 		void OpCodeSev();
 		void OpCodeSez();
 		void OpCodeClz();
-		void OpCodeEhx();
 };
 
 } // namespace MKBasic

--- a/MKCpu.h
+++ b/MKCpu.h
@@ -159,7 +159,7 @@ enum eOpCodes {
 	OPCODE_PHP			= 0x08,	// PusH Processor status on Stack, Implied ($08 : PHP)
 	OPCODE_ORA_IMM	= 0x09,	// bitwise OR with Accumulator, Immediate ($09 arg : ORA #arg ;arg=0..$FF), MEM=PC+1
 	OPCODE_ASL			= 0x0A,	// Arithmetic Shift Left, Accumulator ($0A : ASL)
-	OPCODE_ILL_0B			= 0x0B,	// 6502Q: "Entangled Hadamard" on X register, Hadamard-like operation on X while entangled with the accumulator.
+	OPCODE_ILL_0B			= 0x0B,	// illegal opcode
 	OPCODE_ILL_0C			= 0x0C,	// illegal opcode
 	OPCODE_ORA_ABS	= 0x0D,	// bitwise OR with Accumulator, Absolute ($0D addrlo addrhi : ORA addr ;addr=0..$FFFF), MEM=addr
 	OPCODE_ASL_ABS	= 0x0E,	// Arithmetic Shift Left, Absolute ($0E addrlo addrhi : ASL addr ;addr=0..$FFFF), MEM=addr

--- a/dummy.ram
+++ b/dummy.ram
@@ -395,76 +395,24 @@ $0b00
 ; GINIT:	clq
 ;		ldy #$0c
 ; 		lda #$00
-;		adc #$00 	;clear flags
-;		haa
-; GITER:	seq
-;		sez
-;		clc
-;		cmp #$64
-;		haa
-;		clz
-;		haa
-;               qzz
-;		clq
-;		dey
-;		bne GITER
-;		cmp #$64
-;		bne GINIT
-;		sta $0bff
-;		brk
-;
-$1f $a0 $0c $a9 $00 $69 $00 $02 $3f $2b $18 $c9 $64 $02 $47 $02
-$f7 $1f $88 $d0 $f3 $c9 $64 $d0 $e7 $81 $ff $0b $00
-ORG
-$0c00
-;
-; test program #12
-; address: $0c00
-; Search lookup table in $0f00 to $0fff with amplitude amplification
-; store result in $0bff
-;
-; GINIT:	clq
-;		ldy #$0c
-; 		ldx #$00
 ;		seq
-;               hax
-;               lda $0f00,X
 ;               cln
 ;               clv
+;		haa
 ; GITER:	seq
 ;		sez
-;		clc
 ;		cmp #$64
-;		ehx
-;		qzz
+;               qzz
+;		haa
 ;		clz
-;		ehx
-;		clq
-;		dey
+;		haa
+; 		clq
+; 		dey
 ;		bne GITER
 ;		cmp #$64
 ;		bne GINIT
-;		stx $0cff
+;		stx $0bff
 ;		brk
 ;
-$1f $a0 $0c $a2 $00 $3f $03 $bd $00 $0f $2f $b8 $3f $2b $18 $c9
-$64 $0b $47 $0b $f7 $1f $88 $d0 $f3 $c9 $64 $d0 $e3 $8e $ff $0c
-$00 
-ORG
-$0f00
-$ff $fe $fd $fc $fb $fa $f9 $f8 $f7 $f6 $f5 $f4 $f3 $f2 $f1 $f0
-$ef $ee $ed $ec $eb $ea $e9 $e8 $e7 $e6 $e5 $e4 $e3 $e2 $e1 $e0
-$df $de $dd $dc $db $da $d9 $d8 $d7 $d6 $d5 $d4 $d3 $d2 $d1 $d0
-$cf $ce $cd $cc $cb $ca $c9 $c8 $c7 $c6 $c5 $c4 $c3 $c2 $c1 $c0
-$bf $be $bd $bc $bb $ba $b9 $b8 $b7 $b6 $b5 $b4 $b3 $b2 $b1 $b0
-$af $ae $ad $ac $ab $aa $a9 $a8 $a7 $a6 $a5 $a4 $a3 $a2 $a1 $a0
-$9f $9e $9d $9c $9b $9a $99 $98 $97 $96 $95 $94 $93 $92 $91 $90
-$8f $8e $8d $8c $8b $8a $89 $88 $87 $86 $85 $84 $83 $82 $81 $80
-$7f $7e $7d $7c $7b $7a $79 $78 $77 $76 $75 $74 $73 $72 $71 $70
-$6f $6e $6d $6c $6b $6a $69 $68 $67 $66 $65 $64 $63 $62 $61 $60
-$5f $5e $5d $5c $5b $5a $59 $58 $57 $56 $55 $54 $53 $52 $51 $50
-$4f $4e $4d $4c $4b $4a $49 $48 $47 $46 $45 $44 $43 $42 $41 $40
-$3f $3e $3d $3c $3b $3a $39 $38 $37 $36 $35 $34 $33 $32 $31 $30
-$2f $2e $2d $2c $2b $2a $29 $28 $27 $26 $25 $24 $23 $22 $21 $20
-$1f $1e $1d $1c $1b $1a $19 $18 $17 $16 $15 $14 $13 $12 $11 $10
-$0f $0e $0d $0c $0b $0a $09 $08 $07 $06 $05 $04 $03 $02 $01 $00
+$1f $a0 $0c $a9 $00 $3f $2f $b8 $02 $3f $2b $c9 $64 $f7 $02 $47
+$02 $1f $88 $d0 $f4 $c9 $64 $d0 $e7 $8e $ff $0b $00 


### PR DESCRIPTION
"EHX" does not work as intended, and has been removed as superfluous. Example 11, demonstrating Grover's search, has been corrected. Example 12, attempting to generalize Grover's search to lookup table inversion with "EHX," has been removed.

(See also [https://github.com/vm6502q/qrack/pull/26](https://github.com/vm6502q/qrack/pull/26).)