### PR TITLE
Merging from upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ See [ReadMe.txt](https://github.com/vm6502q/vm6502q/blob/master/ReadMe.txt) for 
 
 Clone [qrack](https://github.org/vm6502q/qrack). Follow the instructions on that repository for installing qrack, including OpenCL support.
 
+Specify the SDL2 include directory:
+
+`export SDLDIR=/usr/include/SDL2`
+
+(...Or wherever your SDL2 headers reside on your system.)
+
 (From qrack checkout directory:)
 
 `mkdir _build && cd _build && cmake .. && make install`

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -36,8 +36,9 @@ MOS-6502-compatible virtual computer featuring BASIC interpreter, machine code
 monitor, input/output device emulation etc.
 Main UI of the program works in DOS/shell console.
 Graphics display emulation requires SDL2.
-Makefile are included to build under Windows 32/64 (mingw compiler required)
-and under Linux Ubuntu or Ubuntu based distro.
+The best way is to download source code of SDL2 and build it.
+Makefile-s are included to build under Windows 32/64 (mingw compiler required)
+and under Linux Ubuntu or Ubuntu based distro (GNU make).
 SDL2 library must be on your execution path in order to run program.
 E.g.:
 set PATH=C:\src\SDL\lib\x64;%PATH%
@@ -46,6 +47,7 @@ To build under Windows 32/64:
 
 * Install MINGW64 under C:\mingw-w64\x86_64-5.3.0 folder.
 * Run mingw terminal.
+* Build SDL2 library.
 * Change current directory to that of this project.
 * Set environment variable SDLDIR. (E.g.: set SDLDIR=C:\src\SDL)
 * Run: makeming.bat
@@ -53,9 +55,20 @@ To build under Windows 32/64:
 To build under Linux:
 
 * Make sure C++11 compliant version of GCC compiler is installed.
+  NOTE: Under older distros, e.g.: Ubuntu Server 12.04, the newest c++
+        compiler installed may not be modern enough. Follow instructions
+        for your distro to install compatible c++ compiler.
+        E.g.: 
+  https://gist.github.com/application2000/73fd6f4bf1be6600a2cf9f56315a2d91 
+* Build SDL2 library (make, make install) or download C/C++ headers and
+  install SDL2 from binary installation package.
 * Change current directory to that of this project.
-* Set environment variable SDLDIR.
+* Set environment variable SDLDIR. Your C/C++ headers for SDL2 should exist
+  in $SDLDIR/include folder.
 * Run: make clean all
+NOTE: To run the emulator under Linux, it may be necessary to set env.
+      variable LD_LIBRARY_PATH, e.g.:
+      export LD_LIBRARY_PATH=/usr/local/lib
 
 Program passed following tests:
 

--- a/makefile
+++ b/makefile
@@ -1,21 +1,39 @@
-# Project: MKBasic
+# Project: VM65
 
 SDLBASE  = $(SDLDIR)
-SDLINCS   = -I"/usr/include/SDL2"
+SDLINCS   = -I$(SDLDIR)
 CPP      = g++ -D__DEBUG__ -DLINUX
 CC       = gcc -D__DEBUG__
 OBJ      = main.o VMachine.o MKCpu.o Memory.o Display.o GraphDisp.o MemMapDev.o MKGenException.o ConsoleIO.o MassStorage.o
 LINKOBJ  = main.o VMachine.o MKCpu.o Memory.o Display.o GraphDisp.o MemMapDev.o MKGenException.o ConsoleIO.o MassStorage.o
 BIN      = vm65
-SDLLIBS  = -L/usr/lib -lSDL2main -lSDL2
-LIBS     = -lqrack -static-libgcc -m64 -g3 -ltermcap -lncurses -lpthread -lm
-CLIBS    = -static-libgcc -m64 -g3
+SDLLIBS  = -L/usr/local/lib -lSDL2main -lSDL2
 INCS     =
-
-CXXINCS  = $(SDLINCS) $(QRACKINCS)
-CXXFLAGS = $(CXXINCS) -m64 -std=c++11 -Wall -pedantic -g3 -fpermissive
+CXXINCS  = 
+ifeq ($(SDLBASE),)
+   $(error ***** SDLDIR not set)
+endif
+ifneq "$(HOSTTYPE)" ""
+   $(info ***** HOSTTYPE already set)
+else
+   $(info ***** HOSTTYPE not set. Setting...)
+   HOSTTYPE = $(shell arch)
+endif
+$(info ***** SDLDIR = $(SDLDIR))
+$(info ***** HOSTTYPE = $(HOSTTYPE))
+ifeq ($(HOSTTYPE),x86_64)
+   $(info ***** 64-bit)
+   LIBS     = -lqrack -static-libgcc -g3 -ltermcap -lncurses -lpthread -lm
+   CLIBS    = -static-libgcc -g3
+   CXXFLAGS = $(CXXINCS) -std=c++11 -pthread -Wall -pedantic -g3 -fpermissive
+else
+   $(info ***** 32-bit)
+   LIBS     = -lqrack -static-libgcc -m32 -g3 -ltermcap -lncurses -lpthread -lm
+   CLIBS    = -static-libgcc -m32 -g3
+   CXXFLAGS = $(CXXINCS) -m32 -std=c++11 -pthread -Wall -pedantic -g3 -fpermissive
+endif
 #CFLAGS   = $(INCS) -m32 -std=c++0x -Wall -pedantic -g3
-CFLAGS   = $(INCS) -m64 -Wall -pedantic -g3
+CFLAGS   = $(INCS) -Wall -pedantic -g3
 RM       = rm -f
 
 ENABLE_OPENCL ?= 1
@@ -42,19 +60,19 @@ $(BIN): ${OBJ}
 	$(CPP) $(LINKOBJ) $(QRACKLIBS) -o $(BIN) $(LDFLAGS) $(LIBS) $(SDLLIBS)
 
 main.o: main.cpp
-	$(CPP) -c main.cpp -o main.o $(CXXFLAGS)
+	$(CPP) -c main.cpp -o main.o $(CXXFLAGS) $(SDLINCS)
 
 VMachine.o: VMachine.cpp
-	$(CPP) -c VMachine.cpp -o VMachine.o $(CXXFLAGS)
+	$(CPP) -c VMachine.cpp -o VMachine.o $(CXXFLAGS) $(SDLINCS)
 
 MKBasic.o: MKBasic.cpp
 	$(CPP) -c MKBasic.cpp -o MKBasic.o $(CXXFLAGS)
 
 MKCpu.o: MKCpu.cpp
-	$(CPP) -c MKCpu.cpp -o MKCpu.o $(CXXFLAGS)
+	$(CPP) -c MKCpu.cpp -o MKCpu.o $(CXXFLAGS) $(SDLINCS)
 
 Memory.o: Memory.cpp
-	$(CPP) -c Memory.cpp -o Memory.o $(CXXFLAGS)
+	$(CPP) -c Memory.cpp -o Memory.o $(CXXFLAGS) $(SDLINCS)
 
 Display.o: Display.cpp
 	$(CPP) -c Display.cpp -o Display.o $(CXXFLAGS)
@@ -66,10 +84,10 @@ MKGenException.o: MKGenException.cpp
 	$(CPP) -c MKGenException.cpp -o MKGenException.o $(CXXFLAGS)
 
 GraphDisp.o: GraphDisp.cpp GraphDisp.h
-	$(CPP) -c GraphDisp.cpp -o GraphDisp.o $(CXXFLAGS)
+	$(CPP) -c GraphDisp.cpp -o GraphDisp.o $(CXXFLAGS) $(SDLINCS)
 
 MemMapDev.o: MemMapDev.cpp MemMapDev.h
-	$(CPP) -c MemMapDev.cpp -o MemMapDev.o $(CXXFLAGS)
+	$(CPP) -c MemMapDev.cpp -o MemMapDev.o $(CXXFLAGS) $(SDLINCS)
 
 ConsoleIO.o: ConsoleIO.cpp ConsoleIO.h
 	$(CPP) -c ConsoleIO.cpp -o ConsoleIO.o $(CXXFLAGS)	


### PR DESCRIPTION
The Qrack framework has moved a ways beyond the original VM6502(Q) project, but I still want to support it. Thank you to the Marek Karcz for making and maintaining the awesome MOS-6502 emulator. (I hope you notice we acknowledged you in the Qrack README!) I want to test and accept the upstream changes, and I want to make sure our changes to the emulator still work with the recent state of development of Qrack.

I have tested that the Grover's search of a lookup table still works, and I believe this is ready to merge.